### PR TITLE
Fix max item limit and enable MHTML downloads

### DIFF
--- a/background.js
+++ b/background.js
@@ -2,26 +2,36 @@
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   if (msg?.type === 'ARCHIVER_SAVE_MHTML') {
     const tabId = msg.tabId;
-    if (!tabId) return;
+    if (!tabId) {
+      sendResponse({ ok: false, error: 'No tabId' });
+      return;
+    }
 
     try {
       chrome.pageCapture.saveAsMHTML({ tabId }, (mhtmlData) => {
         if (chrome.runtime.lastError) {
           console.error('MHTML save error:', chrome.runtime.lastError.message);
+          sendResponse({ ok: false, error: chrome.runtime.lastError.message });
           return;
         }
         const blob = mhtmlData; // Blob
         const url = URL.createObjectURL(blob);
         const ts = new Date().toISOString().replace(/[:.]/g, '-');
-        chrome.downloads.download({
-          url,
-          filename: `civitai-archive-${ts}.mhtml`
-        }, (downloadId) => {
-          setTimeout(() => URL.revokeObjectURL(url), 60_000);
-        });
+        chrome.downloads.download(
+          {
+            url,
+            filename: `civitai-archive-${ts}.mhtml`
+          },
+          () => {
+            setTimeout(() => URL.revokeObjectURL(url), 60_000);
+            sendResponse({ ok: true });
+          }
+        );
       });
     } catch (e) {
       console.error('saveAsMHTML threw:', e);
+      sendResponse({ ok: false, error: String(e) });
     }
+    return true; // Keep service worker alive for async sendResponse
   }
 });


### PR DESCRIPTION
## Summary
- Load max item setting before capture and guard capture loops to stop at the limit
- Keep service worker alive and return responses while saving MHTML so downloads trigger reliably

## Testing
- `node --check background.js`
- `node --check content/archiver.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b367d1445083299577bc0355dc1b7b