### PR TITLE
fix: prompt for MHTML save

### DIFF
--- a/background.js
+++ b/background.js
@@ -20,11 +20,17 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
         chrome.downloads.download(
           {
             url,
-            filename: `civitai-archive-${ts}.mhtml`
+            filename: `civitai-archive-${ts}.mhtml`,
+            saveAs: true
           },
-          () => {
+          (downloadId) => {
+            if (chrome.runtime.lastError) {
+              console.error('Download error:', chrome.runtime.lastError.message);
+              sendResponse({ ok: false, error: chrome.runtime.lastError.message });
+              return;
+            }
             setTimeout(() => URL.revokeObjectURL(url), 60_000);
-            sendResponse({ ok: true });
+            sendResponse({ ok: true, downloadId });
           }
         );
       });


### PR DESCRIPTION
## Summary
- ensure MHTML downloads prompt users to choose save location
- add error handling for download failures

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b36bb81f748329820f1f3c3cae79df