### PR TITLE
Fix MHTML save

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -32,7 +32,19 @@ document.getElementById('stop').addEventListener('click', async () => {
 
 document.getElementById('save').addEventListener('click', async () => {
   const tab = await getActiveTab();
-  chrome.runtime.sendMessage({ type: 'ARCHIVER_SAVE_MHTML', tabId: tab.id });
+  try {
+    const mhtmlData = await chrome.pageCapture.saveAsMHTML({ tabId: tab.id });
+    const url = URL.createObjectURL(mhtmlData);
+    const ts = new Date().toISOString().replace(/[:.]/g, '-');
+    await chrome.downloads.download({
+      url,
+      filename: `civitai-archive-${ts}.mhtml`,
+      saveAs: true
+    });
+    setTimeout(() => URL.revokeObjectURL(url), 60_000);
+  } catch (e) {
+    console.error('MHTML save error:', e);
+  }
 });
 
 restoreOptions();

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -1,0 +1,35 @@
+document.body.innerHTML = `
+  <button id="start"></button>
+  <button id="stop"></button>
+  <button id="save"></button>
+  <input id="maxItems" />
+  <span id="seen"></span>
+  <span id="captured"></span>
+  <span id="deduped"></span>
+`;
+
+global.URL.createObjectURL = jest.fn(() => 'blob:fake');
+global.URL.revokeObjectURL = jest.fn();
+
+global.chrome = {
+  tabs: {
+    query: jest.fn(() => Promise.resolve([{ id: 123 }])),
+    sendMessage: jest.fn()
+  },
+  pageCapture: { saveAsMHTML: jest.fn(() => Promise.resolve(new Blob(['test'], { type: 'text/plain' }))) },
+  downloads: { download: jest.fn(() => Promise.resolve(1)) },
+  storage: { local: { get: jest.fn((defaults, cb) => cb(defaults)), set: jest.fn() } },
+  runtime: { onMessage: { addListener: jest.fn() } }
+};
+
+require('../popup.js');
+
+test('save button triggers page capture and download', async () => {
+  document.getElementById('save').click();
+  // Wait microtasks for async handlers
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  expect(chrome.pageCapture.saveAsMHTML).toHaveBeenCalledWith({ tabId: 123 });
+  expect(chrome.downloads.download).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- save gallery directly from the popup using pageCapture and downloads API
- add tests for popup save workflow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3721b71d08329a3e7f1e71e10e634