### PR TITLE
Fix MHTML downloads saving as .txt

### DIFF
--- a/background.js
+++ b/background.js
@@ -14,7 +14,8 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
           sendResponse({ ok: false, error: chrome.runtime.lastError.message });
           return;
         }
-        const blob = mhtmlData; // Blob
+        // Ensure the blob has the correct MIME type so Windows doesn't default to .txt
+        const blob = new Blob([mhtmlData], { type: 'application/x-mimearchive' });
         const url = URL.createObjectURL(blob);
         const ts = new Date().toISOString().replace(/[:.]/g, '-');
         chrome.downloads.download(

--- a/popup.js
+++ b/popup.js
@@ -34,7 +34,9 @@ document.getElementById('save').addEventListener('click', async () => {
   const tab = await getActiveTab();
   try {
     const mhtmlData = await chrome.pageCapture.saveAsMHTML({ tabId: tab.id });
-    const url = URL.createObjectURL(mhtmlData);
+    // Explicitly set the MIME type so the download uses an .mhtml extension
+    const blob = new Blob([mhtmlData], { type: 'application/x-mimearchive' });
+    const url = URL.createObjectURL(blob);
     const ts = new Date().toISOString().replace(/[:.]/g, '-');
     await chrome.downloads.download({
       url,

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -31,5 +31,8 @@ test('save button triggers page capture and download', async () => {
   await Promise.resolve();
   await Promise.resolve();
   expect(chrome.pageCapture.saveAsMHTML).toHaveBeenCalledWith({ tabId: 123 });
+  // ensure we wrap the captured data with the correct MIME type
+  const blobArg = global.URL.createObjectURL.mock.calls[0][0];
+  expect(blobArg.type).toBe('application/x-mimearchive');
   expect(chrome.downloads.download).toHaveBeenCalled();
 });


### PR DESCRIPTION
## Summary
- Ensure captured pages are saved with `application/x-mimearchive` MIME so Windows honors the `.mhtml` extension
- Add test coverage verifying the blob uses the correct MIME type

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3750bd20083299370b18f1cfcc11e