### PR TITLE
Preserve image dimensions in archived gallery

### DIFF
--- a/content/archiver.js
+++ b/content/archiver.js
@@ -31,7 +31,8 @@
       bucket.style.padding = '12px';
       bucket.style.gap = '12px';
       bucket.style.display = 'none';
-      bucket.style.gridTemplateColumns = 'repeat(auto-fill, minmax(200px, 1fr))';
+      bucket.style.flexWrap = 'wrap';
+      bucket.style.alignItems = 'flex-start';
       document.body.appendChild(bucket);
       state.bucket = bucket;
     }
@@ -67,7 +68,7 @@
 
   function createCardClone(detailUrl, imageUrl) {
     const article = document.createElement('article');
-    // Card styling so items render in a grid when saved
+    // Card styling so items render when saved
     article.style.border = '1px solid rgba(255,255,255,0.1)';
     article.style.borderRadius = '8px';
     article.style.padding = '8px';
@@ -82,8 +83,6 @@
 
     const img = document.createElement('img');
     img.src = imageUrl;
-    img.style.width = '100%';
-    img.style.height = 'auto';
     img.style.display = 'block';
     img.style.borderRadius = '6px';
 
@@ -257,8 +256,8 @@
     document.documentElement.style.overflowY = 'auto';
     document.body.style.height = 'auto';
     document.body.style.overflowY = 'auto';
-    // Reveal bucket with grid layout
-    state.bucket.style.display = 'grid';
+    // Reveal bucket with flex layout
+    state.bucket.style.display = 'flex';
   }
 
   async function startRunning() {

--- a/styles/bucket.css
+++ b/styles/bucket.css
@@ -1,14 +1,15 @@
 
-/* Simple static grid for archived items */
+/* Simple flex layout for archived items allowing natural image sizes */
 #civitai-archiver-bucket {
   display: none; /* hidden until freeze */
   box-sizing: border-box;
   padding: 12px;
   gap: 12px;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  flex-wrap: wrap;
+  align-items: flex-start;
 }
 #civitai-archiver-bucket.archiver-freeze {
-  display: grid !important;
+  display: flex !important;
 }
 #civitai-archiver-bucket article {
   border: 1px solid rgba(255,255,255,0.1);
@@ -21,7 +22,7 @@
   color: inherit;
 }
 #civitai-archiver-bucket img {
-  width: 100%;
+  width: auto;
   height: auto;
   display: block;
   border-radius: 6px;


### PR DESCRIPTION
## Summary
- Switch archived bucket from grid to flex so cards size to their images
- Remove forced image width/height so saved gallery respects original dimensions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b37c5464c88329a2798eeab25f65b3