### PR TITLE
fix: ensure auto scrolling captures more items

### DIFF
--- a/content/archiver.js
+++ b/content/archiver.js
@@ -243,7 +243,9 @@
         }
       }
 
-      if ((scrollEl.scrollTop + scrollEl.clientHeight) >= (scrollEl.scrollHeight - 50)) {
+      const canScroll = (scrollEl.scrollHeight - scrollEl.clientHeight) > 100;
+      const nearBottom = (scrollEl.scrollTop + scrollEl.clientHeight) >= (scrollEl.scrollHeight - 50);
+      if (canScroll && nearBottom) {
         // likely end of page
         stopRunning(true);
         break;
@@ -275,6 +277,8 @@
     state.maxItems = parseInt(opts.maxItems, 10) || 100;
     ensureBucket();
     startObserver();
+    const scrollEl = getScrollElement();
+    scrollEl.scrollTo(0, 0);
     scanOnce();
     autoScrollLoop();
   }


### PR DESCRIPTION
## Summary
- scroll to top before capturing so the extension can walk through the gallery
- guard against false bottom detection by checking for scrollable height

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68b38394ff008329acb51045e00f7ab7