### PR TITLE
Add total image tracking and progress feedback

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -18,10 +18,14 @@
       <button id="stop">Stop</button>
     </div>
     <div class="row">
-      <button id="save">Save as MHTML</button>
+      <button id="save" disabled>Save as MHTML</button>
+    </div>
+    <div class="row">
+      <progress id="progress" value="0" max="0" style="width:100%"></progress>
+      <div id="status"></div>
     </div>
     <div class="row stat">
-      Seen: <span id="seen">0</span> &nbsp; Captured: <span id="captured">0</span> &nbsp; Deduped: <span id="deduped">0</span>
+      Seen: <span id="seen">0</span> &nbsp; Captured: <span id="captured">0</span> &nbsp; Deduped: <span id="deduped">0</span> &nbsp; Total: <span id="total">0</span>
     </div>
     <div class="row">
       <label>Max items: <input id="maxItems" type="number" min="10" max="100000" step="10" value="100"></label>

--- a/popup.js
+++ b/popup.js
@@ -50,6 +50,7 @@ document.getElementById('save').addEventListener('click', async () => {
 });
 
 restoreOptions();
+document.getElementById('status').textContent = '';
 
 // Live stats
 chrome.runtime.onMessage.addListener((msg, sender) => {
@@ -57,5 +58,20 @@ chrome.runtime.onMessage.addListener((msg, sender) => {
     document.getElementById('seen').textContent = String(msg.seen ?? 0);
     document.getElementById('captured').textContent = String(msg.captured ?? 0);
     document.getElementById('deduped').textContent = String(msg.deduped ?? 0);
+    document.getElementById('total').textContent = String(msg.total ?? 0);
+  }
+  if (msg?.type === 'ARCHIVER_STATE') {
+    const progress = document.getElementById('progress');
+    progress.max = msg.maxItems ?? 0;
+    progress.value = msg.captured ?? 0;
+    const statusEl = document.getElementById('status');
+    const saveBtn = document.getElementById('save');
+    if (msg.running) {
+      statusEl.textContent = 'Capturing...';
+      saveBtn.disabled = true;
+    } else {
+      statusEl.textContent = 'Ready to Save';
+      saveBtn.disabled = false;
+    }
   }
 });

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -6,6 +6,9 @@ document.body.innerHTML = `
   <span id="seen"></span>
   <span id="captured"></span>
   <span id="deduped"></span>
+  <span id="total"></span>
+  <progress id="progress"></progress>
+  <div id="status"></div>
 `;
 
 global.URL.createObjectURL = jest.fn(() => 'blob:fake');
@@ -25,6 +28,7 @@ global.chrome = {
 require('../popup.js');
 
 test('save button triggers page capture and download', async () => {
+  document.getElementById('save').disabled = false;
   document.getElementById('save').click();
   // Wait microtasks for async handlers
   await Promise.resolve();


### PR DESCRIPTION
## Summary
- Track all image URLs destined for the archive and report an accurate total count
- Provide progress bar and status messaging with save button enabled only when capture completes
- Update popup tests for new UI elements

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3a57a25648329bb41343b5e9f85cb