### PR TITLE
Stop autoscroll after save and restore scroll styles

### DIFF
--- a/content/archiver.js
+++ b/content/archiver.js
@@ -17,6 +17,10 @@
     lastNewItemAt: 0,
     bucket: null,
     scrollEl: null,
+    origDocHeight: '',
+    origDocOverflowY: '',
+    origBodyHeight: '',
+    origBodyOverflowY: '',
   };
 
   const SEL_ANCHOR_IMG = 'a[href*="/images/"] img, a[href^="/images/"] img';
@@ -241,11 +245,11 @@
     }
   }
 
-  function resetScrollStyles() {
-    document.documentElement.style.height = 'auto';
-    document.documentElement.style.overflowY = 'auto';
-    document.body.style.height = 'auto';
-    document.body.style.overflowY = 'auto';
+  function restoreScrollStyles() {
+    document.documentElement.style.height = state.origDocHeight || '';
+    document.documentElement.style.overflowY = state.origDocOverflowY || '';
+    document.body.style.height = state.origBodyHeight || '';
+    document.body.style.overflowY = state.origBodyOverflowY || '';
   }
 
   function freezePage() {
@@ -254,7 +258,6 @@
     // static grid for the MHTML export. Now that the browser reliably captures
     // the full page, keep the app visible and leave the bucket hidden so the
     // saved archive doesn't include a duplicate grid.
-    resetScrollStyles();
     // Ensure bucket stays hidden
     state.bucket.style.display = 'none';
   }
@@ -262,6 +265,14 @@
   async function startRunning() {
     if (state.running) return;
     state.running = true;
+    state.origDocHeight = document.documentElement.style.height;
+    state.origDocOverflowY = document.documentElement.style.overflowY;
+    state.origBodyHeight = document.body.style.height;
+    state.origBodyOverflowY = document.body.style.overflowY;
+    document.documentElement.style.height = 'auto';
+    document.documentElement.style.overflowY = 'auto';
+    document.body.style.height = 'auto';
+    document.body.style.overflowY = 'auto';
     state.seen = 0;
     state.captured = 0;
     state.deduped = 0;
@@ -286,7 +297,6 @@
     state.scrollEl = getScrollElement();
     state.scrollEl.scrollTo(0, 0);
     scanOnce();
-    resetScrollStyles();
     autoScrollLoop();
   }
 
@@ -298,6 +308,7 @@
       state.bucket.remove();
       state.bucket = null;
     }
+    restoreScrollStyles();
     postState();
   }
 

--- a/popup.js
+++ b/popup.js
@@ -47,6 +47,7 @@ document.getElementById('save').addEventListener('click', async () => {
       filename: `civitai-archive-${ts}.mhtml`,
       saveAs: true
     });
+    chrome.tabs.sendMessage(tab.id, { type: 'ARCHIVER_STOP' });
     setTimeout(() => URL.revokeObjectURL(url), 60_000);
   } catch (e) {
     console.error('MHTML save error:', e);

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -36,9 +36,11 @@ test('save button triggers page capture and download', async () => {
   await Promise.resolve();
   await Promise.resolve();
   await Promise.resolve();
+  await new Promise(r => setTimeout(r, 0));
   expect(chrome.pageCapture.saveAsMHTML).toHaveBeenCalledWith({ tabId: 123 });
   // ensure we wrap the captured data with the correct MIME type
   const blobArg = global.URL.createObjectURL.mock.calls[0][0];
   expect(blobArg.type).toBe('application/x-mimearchive');
   expect(chrome.downloads.download).toHaveBeenCalled();
+  expect(chrome.tabs.sendMessage).toHaveBeenLastCalledWith(123, { type: 'ARCHIVER_STOP' });
 });


### PR DESCRIPTION
## Summary
- stop auto-scroll after saving MHTML by notifying content script
- cache and restore original document/body scroll styles when archiving stops
- extend popup test to cover stop message

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3c17a6ff08329a9f18169866e7d3b