### PR TITLE
Implement reset reload for Brave extension

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -34,7 +34,8 @@ document.getElementById('stop').addEventListener('click', async () => {
   chrome.tabs.sendMessage(tab.id, { type: 'ARCHIVER_STOP' });
 });
 
-document.getElementById('reset').addEventListener('click', () => {
+document.getElementById('reset').addEventListener('click', async () => {
+  await sendToContent('ARCHIVER_RESET');
   chrome.runtime.reload();
 });
 

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -43,9 +43,15 @@ test('save button triggers page capture and download', async () => {
   expect(chrome.downloads.download).toHaveBeenCalled();
 });
 
-test('reset button reloads the extension', async () => {
+test('reset button stops autoscroll then reloads the extension', async () => {
   chrome.runtime.reload.mockClear();
+  chrome.tabs.sendMessage.mockClear();
   document.getElementById('reset').click();
+  // wait for async handler to complete
   await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(123, { type: 'ARCHIVER_RESET', payload: {} });
   expect(chrome.runtime.reload).toHaveBeenCalled();
+  expect(chrome.tabs.sendMessage.mock.invocationCallOrder[0]).toBeLessThan(chrome.runtime.reload.mock.invocationCallOrder[0]);
 });


### PR DESCRIPTION
## Summary
- Reload the extension when the Reset button is clicked
- Update popup unit test for extension reload behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3ee1e50488329b908747a12d450b7