### PR TITLE
Rename extension to Gallery Archiver by Dawnflare

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Civitai Gallery Archiver
+# Gallery Archiver by Dawnflare
 
-Brave/Chromium extension that hoards Civitai infinite‑scroll galleries and saves them as a **single MHTML** file.
+Brave/Chromium extension that hoards infinite‑scroll galleries and saves them as a **single MHTML** file. Built for Civitai but can work on similar gallery pages.
 
 ## Features
 - **Autoscroll capture** – start the extension and it automatically scrolls through the gallery, collecting high‑resolution images until the limit is reached or you stop it.
@@ -13,8 +13,8 @@ Brave/Chromium extension that hoards Civitai infinite‑scroll galleries and sav
 
 ## Install (dev)
 1. Open Brave → `brave://extensions/` and enable **Developer mode** (top‑right).
-2. Click **Load unpacked** and select this folder (`civitai-gallery-archiver/`).
-3. Pin the extension, open a Civitai gallery page, and use the popup controls.
+2. Click **Load unpacked** and select this folder (`GalleryArchiver/`).
+3. Pin the extension, open a gallery page (e.g. on Civitai), and use the popup controls.
 
 ## Notes
 - Works best when you save immediately after stopping (resources stay warm in cache).
@@ -22,6 +22,6 @@ Brave/Chromium extension that hoards Civitai infinite‑scroll galleries and sav
 - Change these values in the popup before pressing **Start**.
 
 ## Roadmap
-- Robust selectors & heuristics for different Civitai gallery layouts.
+- Robust selectors & heuristics for different gallery layouts (starting with Civitai).
 - Size warnings for very large captures.
 - Optional single‑HTML exporter (later).

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
-  "name": "Civitai Gallery Archiver",
+  "name": "Gallery Archiver by Dawnflare",
   "version": "0.1.0",
-  "description": "Capture Civitai infinite galleries into a single MHTML with clickable links per image. Core build: MHTML-only, no enrichment.",
+  "description": "Capture infinite-scroll galleries into a single MHTML with clickable links per image. Core build: MHTML-only, no enrichment.",
   "permissions": [
     "activeTab",
     "scripting",
@@ -18,7 +18,7 @@
   },
   "action": {
     "default_popup": "popup.html",
-    "default_title": "Civitai Archiver"
+    "default_title": "Gallery Archiver by Dawnflare"
   },
   "content_scripts": [
     {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "galleryarchiver",
   "version": "1.0.0",
-  "description": "Brave/Chromium extension to capture Civitai infinite-scroll galleries as a **single MHTML** file.   **Core-only**: MHTML exporter, no enrichment, default max items = 100 for fast iteration.",
+  "description": "Brave/Chromium extension to capture infinite-scroll galleries as a **single MHTML** file.   **Core-only**: MHTML exporter, no enrichment, default max items = 100 for fast iteration.",
   "main": "background.js",
   "directories": {
     "doc": "docs"

--- a/popup.html
+++ b/popup.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <title>Civitai Archiver</title>
+    <title>Gallery Archiver by Dawnflare</title>
     <style>
       body { font-family: system-ui, Arial, sans-serif; margin: 12px; min-width: 260px; color: #eee; background: #222; }
       button { margin-right: 8px; margin-bottom: 8px; }


### PR DESCRIPTION
## Summary
- rename extension and tooltip to "Gallery Archiver by Dawnflare"
- generalize descriptions and README to note broader gallery support

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b53a9edce08329b0a58e02a63464d5