### PR TITLE
feat: Save video first frames with play glyph + scoped gallery layout; prepare-before-capture (100/30)

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,44 +1,81 @@
-// Background/service worker
-chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
-  if (msg?.type === 'ARCHIVER_SAVE_MHTML') {
-    const tabId = msg.tabId;
-    if (!tabId) {
-      sendResponse({ ok: false, error: 'No tabId' });
-      return;
-    }
+// background.js (drop-in)
 
-    try {
-      chrome.pageCapture.saveAsMHTML({ tabId }, (mhtmlData) => {
-        if (chrome.runtime.lastError) {
-          console.error('MHTML save error:', chrome.runtime.lastError.message);
-          sendResponse({ ok: false, error: chrome.runtime.lastError.message });
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (!msg) return;
+
+  // Save the active tab as MHTML (with a PREPARE step first)
+  if (msg.type === 'ARCHIVER_SAVE_MHTML') {
+    (async () => {
+      try {
+        // Determine the tab to save
+        const tabId = msg.tabId || sender?.tab?.id;
+        if (!tabId) {
+          console.warn('[BG] no tabId for save');
+          sendResponse({ ok: false, error: 'no tabId' });
           return;
         }
-        // Ensure the blob has the correct MIME type so Windows doesn't default to .txt
-        const blob = new Blob([mhtmlData], { type: 'application/x-mimearchive' });
-        const url = URL.createObjectURL(blob);
-        const ts = new Date().toISOString().replace(/[:.]/g, '-');
-        chrome.downloads.download(
-          {
-            url,
-            filename: `civitai-archive-${ts}.mhtml`,
-            saveAs: true
-          },
-          (downloadId) => {
+
+        console.log('[BG] ARCHIVER_SAVE_MHTML received → PREPARE start');
+
+        // Ask content to prepare (overlays, layout tweaks, etc.)
+        const prep = await new Promise((resolve) => {
+          let done = false;
+
+          chrome.tabs.sendMessage(tabId, { type: 'ARCHIVER_PREPARE_FOR_SAVE' }, (resp) => {
+            done = true;
             if (chrome.runtime.lastError) {
-              console.error('Download error:', chrome.runtime.lastError.message);
-              sendResponse({ ok: false, error: chrome.runtime.lastError.message });
-              return;
+              console.warn('[BG] PREPARE error:', chrome.runtime.lastError.message);
+              resolve({ ok: false, error: chrome.runtime.lastError.message });
+            } else {
+              resolve(resp || { ok: true });
             }
-            setTimeout(() => URL.revokeObjectURL(url), 60_000);
-            sendResponse({ ok: true, downloadId });
+          });
+
+          // Failsafe timeout
+          setTimeout(() => { if (!done) resolve({ ok: false, error: 'timeout' }); }, 1500);
+        });
+
+        console.log('[BG] PREPARE result:', prep);
+
+        // Small settle to let the DOM paint before snapshot
+        await new Promise((r) => setTimeout(r, 100));
+
+        // Capture → Blob
+        chrome.pageCapture.saveAsMHTML({ tabId }, async (blob) => {
+          if (!blob) {
+            console.error('[BG] pageCapture returned empty blob');
+            sendResponse({ ok: false, error: 'empty blob' });
+            return;
           }
-        );
-      });
-    } catch (e) {
-      console.error('saveAsMHTML threw:', e);
-      sendResponse({ ok: false, error: String(e) });
-    }
-    return true; // Keep service worker alive for async sendResponse
+
+          console.log('[BG] converting blob to object URL');
+          const url = URL.createObjectURL(blob);
+
+          const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+          const filename = `civitai-archive-${stamp}.mhtml`;
+
+          try {
+            const id = await chrome.downloads.download({
+              url,
+              filename,
+              saveAs: true
+            });
+            console.log('[BG] download started:', id);
+            // keep URL alive a little while
+            setTimeout(() => URL.revokeObjectURL(url), 30000);
+            sendResponse({ ok: true, downloadId: id });
+          } catch (e) {
+            console.error('[BG] download error:', e);
+            sendResponse({ ok: false, error: String(e) });
+          }
+        });
+      } catch (e) {
+        console.error('[BG] save flow error:', e);
+        sendResponse({ ok: false, error: String(e) });
+      }
+    })();
+
+    // async response
+    return true;
   }
 });

--- a/content/archiver.js
+++ b/content/archiver.js
@@ -328,3 +328,357 @@
       module.exports = { absUrl, pickBestFromSrcset, isTinyDataURI };
     }
   })();
+
+// ------------------------------------------------------------
+// [Archiver] PREPARE: replace gallery <video> with still <img>
+// ------------------------------------------------------------
+(function () {
+  const A_IMG_PAGE = 'a[href*="/images/"], a[href^="/images/"]';
+
+  // Try to capture a first frame if poster is missing and CORS allows
+  async function captureFirstFrameToDataURL(src) {
+    try {
+      const v = document.createElement('video');
+      v.crossOrigin = 'anonymous';   // CORS-friendly servers will allow canvas use
+      v.muted = true;
+      v.playsInline = true;
+      v.preload = 'auto';
+      v.src = src;
+
+      await new Promise((res, rej) => {
+        const to = setTimeout(() => rej(new Error('video load timeout')), 4000);
+        v.addEventListener('loadeddata', () => { clearTimeout(to); res(); }, { once: true });
+        v.addEventListener('error', () => { clearTimeout(to); rej(new Error('video load error')); }, { once: true });
+      });
+
+      // nudge to a safe timestamp near 0
+      try {
+        v.currentTime = 0.05;
+        await new Promise((res) => v.addEventListener('seeked', res, { once: true }));
+      } catch (_) { /* some codecs don’t need seek */ }
+
+      const w = Math.max(1, v.videoWidth || 450);
+      const h = Math.max(1, v.videoHeight || Math.round(w * 9 / 16));
+      const c = document.createElement('canvas');
+      c.width = w; c.height = h;
+      const ctx = c.getContext('2d');
+      ctx.drawImage(v, 0, 0, w, h);
+      return c.toDataURL('image/jpeg', 0.9);
+    } catch (_) {
+      return '';
+    }
+  }
+
+  async function videoToStillURL(videoEl) {
+    // 1) Prefer the poster (already optimized on Civitai CDN, tiny and fast)
+    if (videoEl.poster) return videoEl.poster;
+
+    // 2) Otherwise try to grab a frame from an actual source
+    const direct = videoEl.currentSrc ||
+                   (videoEl.querySelector('source') && videoEl.querySelector('source').src) ||
+                   '';
+    if (!direct) return '';
+    return await captureFirstFrameToDataURL(direct);
+  }
+
+  function looksLikeGalleryVideo(v) {
+    // under an anchor to /images/… (the same way we pick image cards)
+    return !!v.closest(A_IMG_PAGE);
+  }
+
+  async function freezeVideosInPlace() {
+    const vids = Array.from(document.querySelectorAll('video'))
+      .filter(looksLikeGalleryVideo)
+      // skip ones we already processed
+      .filter(v => !v.dataset.archiverFrozen);
+
+    let processed = 0, ok = 0, fail = 0, skipped = 0;
+
+    for (const v of vids) {
+      processed++;
+      try {
+        const still = await videoToStillURL(v);
+        if (!still) { skipped++; continue; }
+
+        const img = document.createElement('img');
+        img.src = still;
+        img.alt = 'Video snapshot';
+        // Keep sizing consistent with the original gallery cards
+        img.style.width = '100%';
+        img.style.height = '100%';
+        img.style.objectFit = 'cover';
+        img.style.display = 'block';
+
+        // Replace the <video> in place; anchor/href stays intact
+        v.replaceWith(img);
+        v.dataset.archiverFrozen = '1';
+        ok++;
+      } catch (e) {
+        fail++;
+      }
+    }
+
+    return { processed, ok, fail, skipped, total: vids.length };
+  }
+
+  // Message hook: popup will ask us to prepare the DOM before saving
+  chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
+    if (msg && msg.type === 'ARCHIVER_PREPARE_FOR_SAVE') {
+      (async () => {
+        try {
+          const stats = await freezeVideosInPlace();
+          sendResponse({ ok: true, stats });
+        } catch (e) {
+          sendResponse({ ok: false, error: String(e) });
+        }
+      })();
+      return true; // keep channel open for async response
+    }
+  });
+
+  // Optional debug helper (run in console if needed):
+  //   window.__archiverFreezeVideos = freezeVideosInPlace;
+})();
+
+/* ------------------------------------------------------------------
+ * [Archiver] Scope gallery layout to #gallery
+ *  - Applies 6-col grid only inside #gallery (header/description unchanged)
+ *  - Cleans up injected layout style when ARCHIVER_STOP fires
+ * ------------------------------------------------------------------ */
+(function () {
+  const STYLE_ID_GRID  = 'archiver-gallery-grid-style';
+
+  const $  = (sel, root=document) => root.querySelector(sel);
+  const $$ = (sel, root=document) => Array.from(root.querySelectorAll(sel));
+
+  function getGalleryRoot() {
+    // Prefer explicit id the site uses
+    const g = document.getElementById('gallery');
+    if (g) return g;
+
+    // Fallback: lowest common ancestor of several /images/... anchors
+    const anchors = $$('a[href*="/images/"], a[href^="/images/"]');
+    if (anchors.length < 6) return null;
+    const sample = anchors.slice(0, 20);
+    const chains = sample.map(a => {
+      const list = [];
+      for (let n=a; n && n!==document.documentElement; n=n.parentElement) list.push(n);
+      return list;
+    });
+    let lca = null;
+    for (const cand of chains[0]) {
+      if (chains.every(chain => chain.includes(cand))) { lca = cand; break; }
+    }
+    return (lca && lca !== document.body) ? lca : null;
+  }
+
+  function ensureGridStyles(galleryRoot) {
+    if (!galleryRoot) return;
+    if (document.getElementById(STYLE_ID_GRID)) return;
+
+    const s = document.createElement('style');
+    s.id = STYLE_ID_GRID;
+
+    // IMPORTANT: All rules are hard-scoped under #gallery so header/description don’t change.
+    s.textContent = `
+      /* keep the gallery container full width without touching header */
+      #gallery .mantine-Container-root,
+      #gallery .mantine-container,
+      #gallery [class*="Container-root"] {
+        max-width: 100% !important;
+        width: 100% !important;
+      }
+
+      /* force 6 columns only inside the gallery grid */
+      #gallery .mantine-SimpleGrid-root,
+      #gallery [class*="SimpleGrid-root"],
+      #gallery [class*="simpleGrid"] {
+        display: grid !important;
+        grid-template-columns: repeat(6, minmax(0, 1fr)) !important;
+        gap: 12px !important;
+      }
+    `;
+    document.head.appendChild(s);
+  }
+
+  function cleanup() {
+    const s1 = document.getElementById(STYLE_ID_GRID);
+    if (s1) s1.remove();
+  }
+
+  /* ------------------------- Message integration ------------------------- */
+  chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
+    if (!msg) return;
+    if (msg.type === 'ARCHIVER_PREPARE_FOR_SAVE') {
+      (async () => {
+        try {
+          const root = getGalleryRoot();
+          ensureGridStyles(root);
+          // tiny settle for paint
+          await new Promise(r => setTimeout(r, 30));
+          sendResponse(Object.assign({ ok:true }, res));
+        } catch (e) {
+          sendResponse({ ok:false, error:String(e) });
+        }
+      })();
+      return true; // async
+    }
+    if (msg.type === 'ARCHIVER_STOP') {
+      cleanup();
+    }
+  });
+
+  // Safety: restore on navigation
+  window.addEventListener('beforeunload', cleanup, { once: true });
+})();
+
+/* ------------------------------------------------------------------
+ * [Archiver] Play badge overlay (data:SVG) with re-apply guard
+ *  - Puts a small ▶ overlay inside each video card
+ *  - Keeps re-applying for ~1.2s to survive React re-renders
+ *  - Requires no external CSS, serializes cleanly to MHTML
+ * ------------------------------------------------------------------ */
+(() => {
+  const LOG = (...a)=>{ try { console.log('[Archiver] overlay', ...a);} catch(_){} };
+  const $$  = (sel, root=document) => Array.from(root.querySelectorAll(sel));
+
+  const ATTR_OVERLAY = 'data-archiver-overlay';
+  const ATTR_REL_SET = 'data-archiver-pos-rel';
+
+  function getGalleryRoot() {
+    return document.getElementById('gallery') || document;
+  }
+
+  function svgPlayBadgeDataURL(diamPx) {
+    const d = Math.max(16, Math.floor(diamPx));
+    const r = Math.floor(d/2);
+    const svg = `
+      <svg xmlns="http://www.w3.org/2000/svg" width="${d}" height="${d}" viewBox="0 0 ${d} ${d}">
+        <circle cx="${r}" cy="${r}" r="${r}" fill="rgba(0,0,0,0.55)"/>
+        <polygon points="${Math.floor(r*0.55)},${Math.floor(r*0.35)} ${Math.floor(r*0.55)},${Math.floor(r*1.65)} ${Math.floor(r*1.55)},${r}" fill="#fff"/>
+      </svg>`;
+    return 'data:image/svg+xml;utf8,' + encodeURIComponent(svg);
+  }
+
+  function ensureRelative(container) {
+    const style = (container && container.style) ? container.style : null;
+    if (!style) return;
+    const cs = getComputedStyle(container).position;
+    if (cs !== 'relative' && cs !== 'absolute' && cs !== 'fixed') {
+      style.position = 'relative';
+      container.setAttribute(ATTR_REL_SET, '1');
+    }
+  }
+
+  function cardForPoster(posterImg) {
+    // Prefer the clickable <a href="/images/...">
+    const a = posterImg.closest('a[href*="/images/"]');
+    if (a) return a;
+
+    // Fallback: EdgeVideo wrapper, then its parent container
+    const edge = posterImg.closest('[class^="EdgeVideo_"]');
+    if (edge) return edge;
+
+    // Last resort: the poster's parent
+    return posterImg.parentElement || posterImg;
+  }
+
+  function overlayBadgeForPoster(posterImg) {
+    const card = cardForPoster(posterImg);
+    if (!card) return false;
+
+    if (card.querySelector(`img[${ATTR_OVERLAY}="badge"]`)) return false;
+
+    ensureRelative(card);
+
+    const rect = card.getBoundingClientRect();
+    const size = Math.min(Math.max(Math.floor(Math.min(rect.width, rect.height) * 0.12), 24), 56);
+
+    const img = new Image();
+    img.setAttribute(ATTR_OVERLAY, 'badge');
+    img.alt = '';
+    img.decoding = 'sync';
+    img.loading  = 'eager';
+    img.src = svgPlayBadgeDataURL(size);
+    img.style.cssText = [
+      'position:absolute',
+      'top:8px',
+      'right:8px',
+      `width:${size}px`,
+      `height:${size}px`,
+      'pointer-events:none',
+      'z-index:2147483000',
+      'display:block'
+    ].join(';');
+
+    card.appendChild(img);
+    return true;
+  }
+
+  function collectPosters(root) {
+    return $$(
+      '#gallery a[href*="/images/"] img[alt*="Video"], ' +
+      '#gallery [class^="EdgeVideo_"] img[alt*="Video"], ' +
+      'a[href*="/images/"] img[alt*="Video"]',
+      root
+    );
+  }
+
+  // Re-apply for ~durationMs with a MutationObserver + interval
+  async function guardOverlays(root, durationMs = 1200) {
+    let placed = 0, processed = 0;
+
+    const applyOnce = () => {
+      const posters = collectPosters(root);
+      for (const p of posters) {
+        processed++;
+        if (overlayBadgeForPoster(p)) placed++;
+      }
+    };
+
+    applyOnce();
+
+    const observer = new MutationObserver(() => applyOnce());
+    observer.observe(root || document, { childList: true, subtree: true });
+
+    const tick = setInterval(applyOnce, 120);
+
+    await new Promise(r => setTimeout(r, durationMs));
+
+    clearInterval(tick);
+    observer.disconnect();
+
+    LOG(`placed ${placed}/${processed} (guard ${durationMs}ms)`);
+    return { processed, placed };
+  }
+
+  function cleanupOverlays() {
+    document.querySelectorAll(`img[${ATTR_OVERLAY}="badge"]`).forEach(n => n.remove());
+    document.querySelectorAll(`[${ATTR_REL_SET}="1"]`).forEach(n => {
+      try { n.style.position = ''; } catch(_) {}
+      n.removeAttribute(ATTR_REL_SET);
+    });
+  }
+
+  chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
+    if (!msg) return;
+    if (msg.type === 'ARCHIVER_PREPARE_FOR_SAVE') {
+      (async () => {
+        try {
+          const stats = await guardOverlays(getGalleryRoot(), 1200);
+          // tiny extra settle so BG will almost always catch overlays in paint
+          await new Promise(r => setTimeout(r, 30));
+          sendResponse(Object.assign({ ok: true }, stats));
+        } catch (e) {
+          sendResponse({ ok: false, error: String(e) });
+        }
+      })();
+      return true;
+    }
+    if (msg.type === 'ARCHIVER_STOP') {
+      cleanupOverlays();
+    }
+  });
+
+  window.addEventListener('beforeunload', cleanupOverlays, { once: true });
+})();


### PR DESCRIPTION
PR body checklist

 Replace video cards with first-frame stills (fast + small files)

 Overlay visible ▶ glyph on video stills (no CSS dependency)

 Keep header/description layouts intact; grid scoped to #gallery (6 columns)

 On save: run PREPARE, bake glyphs, tiny settle (BG=100ms / content=30ms), then capture

 After save/stop: restore any styles (no page residue)

 No change to image capture, counters, or autoscroll behavior