### PR TITLE
Add configurable keyboard shortcuts and options page

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Brave/Chromium extension that hoards infinite‑scroll galleries and saves them 
   - **Stop** freezes the page so it can be exported.
   - **Save** downloads the page as an `.mhtml` archive.
   - **Reset** clears all state, reloads the page, and restarts the extension.
-- **Configurable options** – set maximum items, scroll delay, and stability timeout directly in the popup.
+- **Configurable options** – set maximum items in the popup; adjust scroll delay, stability timeout, and keyboard shortcuts on the options page.
 
 ## Install (dev)
 1. Open Brave → `brave://extensions/` and enable **Developer mode** (top‑right).
@@ -18,8 +18,8 @@ Brave/Chromium extension that hoards infinite‑scroll galleries and saves them 
 
 ## Notes
 - Works best when you save immediately after stopping.
-- Defaults: max items = 100, scroll delay = 300 ms, stability timeout = 400 ms.
-- Change these values in the popup before pressing **Start**.
+ - Defaults: max items = 200, scroll delay = 300 ms, stability timeout = 400 ms.
+ - Adjust these values before pressing **Start**.
 
 ## Roadmap
 - Robust selectors & heuristics for different gallery layouts (starting with Civitai).

--- a/content/archiver.js
+++ b/content/archiver.js
@@ -6,7 +6,7 @@
     seen: 0,
     captured: 0,
     deduped: 0,
-    maxItems: 100,
+    maxItems: 200,
     scrollDelay: 300,
     stabilityTimeout: 400,
     items: new Map(), // key -> { detailUrl, imageUrl, el, state }
@@ -265,9 +265,9 @@
     state.allImageUrls = new Set();
     // Load options before starting capture
     const opts = await new Promise(resolve => {
-    chrome.storage.local.get({ maxItems: 100, scrollDelay: 300, stabilityTimeout: 400 }, resolve);
+    chrome.storage.local.get({ maxItems: 200, scrollDelay: 300, stabilityTimeout: 400 }, resolve);
     });
-    state.maxItems = parseInt(opts.maxItems, 10) || 100;
+    state.maxItems = parseInt(opts.maxItems, 10) || 200;
     state.scrollDelay = parseInt(opts.scrollDelay, 10) || 300;
     state.stabilityTimeout = parseInt(opts.stabilityTimeout, 10) || 400;
     // Collect any images already on the page

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -27,12 +27,12 @@ Civitai’s React/virtualized galleries create and remove DOM nodes as you scrol
 ## 5) User Stories
 - Start simple capture → auto‑scrolls and collects images+links → Save as MHTML → single file containing what I saw.
 - Stop anytime and save partial progress.
-- Default **Max items = 100** for rapid testing (user can raise later).
+- Default **Max items = 200** for rapid testing (user can raise later).
 
 ## 6) UX / Controls (Popup)
 - **Buttons:** Start, Stop, Save as MHTML.
 - **Status:** Seen / Captured / Deduped counters; basic progress indicator.
-- **Options (v1):** Max items (default 100).
+- **Options (v1):** Max items (default 200).
 
 ## 7) Technical Approach (Overview)
 1. **Hoarding to bypass virtualization:** Create an **Archive Bucket** (`#civitai-archiver-bucket`) appended to `document.body`, outside the app’s React root. As cards appear, clone static entries into the bucket; each clone contains a clickable `<a href="…/images/…"><img/></a>`.
@@ -64,11 +64,11 @@ Civitai’s React/virtualized galleries create and remove DOM nodes as you scrol
 - Blur/LQIP swaps → stability + quality gates + `srcset` best candidate.
 - CSS background‑image cards → parse computed style.
 - Expiring URLs → save immediately after freeze; keep clones visible.
-- Large runs → default cap 100; warn when increasing.
+- Large runs → default cap 200; warn when increasing.
 
 ## 11) Milestones
 - M0 Scaffold → M1 Clone (manual scroll) → M2 Auto‑scroll → M3 Freeze & Save → M4 Polish.
 
 ## 12) Test Plan
 - Multiple Civitai gallery pages; verify images + anchors in `.mhtml`.
-- Placeholder handling; stopping at 100; larger caps sanity test.
+- Placeholder handling; stopping at 200; larger caps sanity test.

--- a/manifest.json
+++ b/manifest.json
@@ -20,6 +20,7 @@
     "default_popup": "popup.html",
     "default_title": "Gallery Archiver by Dawnflare"
   },
+  "options_page": "options.html",
   "content_scripts": [
     {
       "matches": [

--- a/options.html
+++ b/options.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Gallery Archiver Options</title>
+    <style>
+      body { font-family: system-ui, Arial, sans-serif; margin: 12px; color: #eee; background: #222; }
+      label { display: block; margin-top: 8px; }
+      input[type="number"] { width: 80px; }
+      input[type="text"] { width: 120px; }
+      #status { margin-top: 10px; }
+    </style>
+  </head>
+  <body>
+    <h1>Options</h1>
+    <div>
+      <label>Start shortcut: <input id="startShortcut" type="text" placeholder="Alt+1"></label>
+      <label>Reset shortcut: <input id="resetShortcut" type="text" placeholder="Alt+F5"></label>
+      <label>Save shortcut: <input id="saveShortcut" type="text" placeholder="Alt+2"></label>
+    </div>
+    <div>
+      <label>Scroll delay (ms): <input id="scrollDelay" type="number" min="50" max="5000" step="50"></label>
+      <label>Stability timeout (ms): <input id="stabilityTimeout" type="number" min="100" max="5000" step="100"></label>
+    </div>
+    <button id="save">Save</button>
+    <div id="status"></div>
+    <script src="options.js"></script>
+  </body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,32 @@
+function restoreOptions() {
+  chrome.storage.local.get({
+    startShortcut: 'Alt+1',
+    resetShortcut: 'Alt+F5',
+    saveShortcut: 'Alt+2',
+    scrollDelay: 300,
+    stabilityTimeout: 400
+  }, opts => {
+    document.getElementById('startShortcut').value = opts.startShortcut;
+    document.getElementById('resetShortcut').value = opts.resetShortcut;
+    document.getElementById('saveShortcut').value = opts.saveShortcut;
+    document.getElementById('scrollDelay').value = opts.scrollDelay;
+    document.getElementById('stabilityTimeout').value = opts.stabilityTimeout;
+  });
+}
+
+function saveOptions() {
+  const startShortcut = document.getElementById('startShortcut').value || 'Alt+1';
+  const resetShortcut = document.getElementById('resetShortcut').value || 'Alt+F5';
+  const saveShortcut = document.getElementById('saveShortcut').value || 'Alt+2';
+  const scrollDelay = parseInt(document.getElementById('scrollDelay').value || '300', 10);
+  const stabilityTimeout = parseInt(document.getElementById('stabilityTimeout').value || '400', 10);
+  chrome.storage.local.set({ startShortcut, resetShortcut, saveShortcut, scrollDelay, stabilityTimeout }, () => {
+    const status = document.getElementById('status');
+    status.textContent = 'Options saved.';
+    setTimeout(() => status.textContent = '', 1500);
+  });
+}
+
+document.getElementById('save').addEventListener('click', saveOptions);
+
+document.addEventListener('DOMContentLoaded', restoreOptions);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "galleryarchiver",
   "version": "1.0.0",
-  "description": "Brave/Chromium extension to capture infinite-scroll galleries as a **single MHTML** file.   **Core-only**: MHTML exporter, no enrichment, default max items = 100 for fast iteration.",
+  "description": "Brave/Chromium extension to capture infinite-scroll galleries as a **single MHTML** file.   **Core-only**: MHTML exporter, no enrichment, default max items = 200 for fast iteration.",
   "main": "background.js",
   "directories": {
     "doc": "docs"

--- a/popup.html
+++ b/popup.html
@@ -8,18 +8,19 @@
       button { margin-right: 8px; margin-bottom: 8px; }
       label { display: block; margin-top: 8px; }
       input[type="number"] { width: 80px; }
+      .shortcut { font-size: 0.8em; color: #888; margin-left: 4px; }
       .row { margin: 6px 0; }
       .stat { font-variant-numeric: tabular-nums; }
     </style>
   </head>
   <body>
     <div class="row">
-      <button id="start">Start</button>
+      <button id="start">Start</button><span id="startShortcutLabel" class="shortcut"></span>
       <button id="stop">Stop</button>
-      <button id="reset">Reset</button>
+      <button id="reset">Reset</button><span id="resetShortcutLabel" class="shortcut"></span>
     </div>
     <div class="row">
-      <button id="save">Save as MHTML</button>
+      <button id="save">Save as HTML</button><span id="saveShortcutLabel" class="shortcut"></span>
     </div>
     <div class="row">
       <progress id="progress" value="0" max="0" style="width:100%"></progress>
@@ -29,13 +30,7 @@
       Seen: <span id="seen">0</span> &nbsp; Captured: <span id="captured">0</span> &nbsp; Deduped: <span id="deduped">0</span> &nbsp; Total: <span id="total">0</span>
     </div>
     <div class="row">
-      <label>Max items: <input id="maxItems" type="number" min="10" max="100000" step="10" value="100"></label>
-    </div>
-    <div class="row">
-      <label>Scroll delay (ms): <input id="scrollDelay" type="number" min="50" max="5000" step="50" value="300"></label>
-    </div>
-    <div class="row">
-      <label>Stability timeout (ms): <input id="stabilityTimeout" type="number" min="100" max="5000" step="100" value="400"></label>
+      <label>Max items: <input id="maxItems" type="number" min="10" max="100000" step="10" value="200"></label>
     </div>
     <script src="popup.js"></script>
   </body>

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -1,11 +1,9 @@
 document.body.innerHTML = `
-  <button id="start"></button>
+  <button id="start"></button><span id="startShortcutLabel"></span>
   <button id="stop"></button>
-  <button id="reset"></button>
-  <button id="save"></button>
+  <button id="reset"></button><span id="resetShortcutLabel"></span>
+  <button id="save"></button><span id="saveShortcutLabel"></span>
   <input id="maxItems" />
-  <input id="scrollDelay" />
-  <input id="stabilityTimeout" />
   <span id="seen"></span>
   <span id="captured"></span>
   <span id="deduped"></span>
@@ -37,6 +35,7 @@ test('save button triggers page capture and download', async () => {
   await Promise.resolve();
   await Promise.resolve();
   await Promise.resolve();
+  await new Promise(r => setTimeout(r, 150));
   expect(chrome.pageCapture.saveAsMHTML).toHaveBeenCalledWith({ tabId: 123 });
   // ensure we wrap the captured data with the correct MIME type
   const blobArg = global.URL.createObjectURL.mock.calls[0][0];
@@ -60,4 +59,14 @@ test('reset button stops autoscroll, reloads the page and extension', async () =
   expect(chrome.runtime.reload).toHaveBeenCalled();
   expect(chrome.tabs.sendMessage.mock.invocationCallOrder[0]).toBeLessThan(chrome.tabs.reload.mock.invocationCallOrder[0]);
   expect(chrome.tabs.reload.mock.invocationCallOrder[0]).toBeLessThan(chrome.runtime.reload.mock.invocationCallOrder[0]);
+});
+
+test('save shortcut triggers page capture', async () => {
+  chrome.pageCapture.saveAsMHTML.mockClear();
+  document.dispatchEvent(new KeyboardEvent('keydown', { key: '2', altKey: true }));
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  await new Promise(r => setTimeout(r, 150));
+  expect(chrome.pageCapture.saveAsMHTML).toHaveBeenCalled();
 });


### PR DESCRIPTION
## Summary
- Add configurable keyboard shortcuts for Start, Reset, and Save actions
- Show current shortcuts in popup and rename "Save as HTML" button
- Create options page to tweak shortcuts, scroll delay, and stability timeout
- Keep Max Items in popup and update unit tests
- Set default shortcuts (Start Alt+1, Save Alt+2, Reset Alt+F5) and raise default max items to 200

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b655700a8c832980fc1a5f33ab657d