### PR TITLE
Add Start and Save shortcut to options menu

### DIFF
--- a/options.html
+++ b/options.html
@@ -15,8 +15,9 @@
     <h1>Options</h1>
     <div>
       <label>Start shortcut: <input id="startShortcut" type="text" placeholder="Alt+1"></label>
-      <label>Reset shortcut: <input id="resetShortcut" type="text" placeholder="Alt+Shift+R"></label>
       <label>Save shortcut: <input id="saveShortcut" type="text" placeholder="Alt+2"></label>
+      <label>Start and Save shortcut: <input id="startSaveShortcut" type="text" placeholder="Alt+3"></label>
+      <label>Reset shortcut: <input id="resetShortcut" type="text" placeholder="Alt+Shift+R"></label>
     </div>
     <div>
       <label>Scroll delay (ms): <input id="scrollDelay" type="number" min="50" max="5000" step="50"></label>

--- a/options.js
+++ b/options.js
@@ -10,21 +10,24 @@ function restoreOptions() {
   chrome.commands.getAll(commands => {
     const find = name => commands.find(c => c.name === name)?.shortcut || '';
     document.getElementById('startShortcut').value = find('start') || 'Alt+1';
-    document.getElementById('resetShortcut').value = find('reset') || 'Alt+Shift+R';
     document.getElementById('saveShortcut').value = find('save') || 'Alt+2';
+    document.getElementById('startSaveShortcut').value = find('startAndSave') || 'Alt+3';
+    document.getElementById('resetShortcut').value = find('reset') || 'Alt+Shift+R';
   });
 }
 
 function saveOptions() {
   const startShortcut = document.getElementById('startShortcut').value || 'Alt+1';
-  const resetShortcut = document.getElementById('resetShortcut').value || 'Alt+Shift+R';
   const saveShortcut = document.getElementById('saveShortcut').value || 'Alt+2';
+  const startSaveShortcut = document.getElementById('startSaveShortcut').value || 'Alt+3';
+  const resetShortcut = document.getElementById('resetShortcut').value || 'Alt+Shift+R';
   const scrollDelay = parseInt(document.getElementById('scrollDelay').value || '300', 10);
   const stabilityTimeout = parseInt(document.getElementById('stabilityTimeout').value || '400', 10);
 
   chrome.commands.update({ name: 'start', shortcut: startShortcut });
-  chrome.commands.update({ name: 'reset', shortcut: resetShortcut });
   chrome.commands.update({ name: 'save', shortcut: saveShortcut });
+  chrome.commands.update({ name: 'startAndSave', shortcut: startSaveShortcut });
+  chrome.commands.update({ name: 'reset', shortcut: resetShortcut });
 
   chrome.storage.local.set({ scrollDelay, stabilityTimeout }, () => {
     const status = document.getElementById('status');


### PR DESCRIPTION
## Summary
- Add input for Start and Save shortcut in Options page
- Reorder options: Start, Save, Start and Save, Reset, Scroll delay, Stability timeout
- Update options logic to handle Start and Save shortcut

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b72484c61c8329b5a9853eba006d9e