### PR TITLE
Add Options button to popup

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -30,6 +30,9 @@
       <span class="button-wrapper"><span id="resetShortcutLabel" class="shortcut"></span><button id="reset">Reset</button></span>
       <span class="button-wrapper"><button id="stop">Stop</button></span>
     </div>
+    <div class="row buttons">
+      <span class="button-wrapper"><button id="options">Options</button></span>
+    </div>
     <div class="row">
       <progress id="progress" value="0" max="0" style="width:100%"></progress>
       <div id="status"></div>

--- a/popup.js
+++ b/popup.js
@@ -51,6 +51,10 @@ document.getElementById('startSave').addEventListener('click', () => {
   chrome.runtime.sendMessage({ type: 'ARCHIVER_START_AND_SAVE' });
 });
 
+document.getElementById('options').addEventListener('click', () => {
+  chrome.runtime.openOptionsPage();
+});
+
 document.getElementById('save').addEventListener('click', async () => {
   const tab = await getActiveTab();
 

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -4,6 +4,7 @@ document.body.innerHTML = `
   <span id="startSaveShortcutLabel"></span><button id="startSave"></button>
   <span id="resetShortcutLabel"></span><button id="reset"></button>
   <button id="stop"></button>
+  <button id="options"></button>
   <input id="maxItems" />
   <span id="seen"></span>
   <span id="captured"></span>
@@ -25,7 +26,7 @@ global.chrome = {
   pageCapture: { saveAsMHTML: jest.fn(() => Promise.resolve(new Blob(['test'], { type: 'text/plain' }))) },
   downloads: { download: jest.fn(() => Promise.resolve(1)) },
   storage: { local: { get: jest.fn((defaults, cb) => cb(defaults)), set: jest.fn() } },
-  runtime: { onMessage: { addListener: jest.fn() }, reload: jest.fn(), sendMessage: jest.fn() },
+  runtime: { onMessage: { addListener: jest.fn() }, reload: jest.fn(), sendMessage: jest.fn(), openOptionsPage: jest.fn() },
   commands: { getAll: jest.fn(cb => cb([
     { name: 'start', shortcut: 'Alt+1' },
     { name: 'reset', shortcut: 'Alt+Shift+R' },
@@ -80,4 +81,10 @@ test('startSave button sends start-and-save message', () => {
   chrome.runtime.sendMessage.mockClear();
   document.getElementById('startSave').click();
   expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ type: 'ARCHIVER_START_AND_SAVE' });
+});
+
+test('options button opens the options page', () => {
+  chrome.runtime.openOptionsPage.mockClear();
+  document.getElementById('options').click();
+  expect(chrome.runtime.openOptionsPage).toHaveBeenCalled();
 });


### PR DESCRIPTION
## Summary
- add a dedicated Options button below Stop in the popup
- open the extension's options page when the button is pressed
- cover options button behavior with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7261ee960832985cd9cd4d2b8b89b