### PR TITLE
feat: add configurable filename options

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Brave/Chromium extension that hoards infinite‑scroll galleries and saves them 
   - **Stop** freezes the page so it can be exported.
   - **Save** downloads the page as an `.mhtml` archive.
   - **Reset** clears all state, reloads the page, and restarts the extension.
- - **Configurable options** – set maximum items in the popup; adjust scroll delay, stability timeout, and keyboard shortcuts on the options page (shortcuts also appear under `brave://extensions/shortcuts`).
+- **Configurable options** – set maximum items in the popup; adjust scroll delay, stability timeout, keyboard shortcuts, and customize archive filenames (tab title, URL, domain, or custom text with optional timestamps) on the options page (shortcuts also appear under `brave://extensions/shortcuts`).
 
 ## Install (dev)
 1. Open Brave → `brave://extensions/` and enable **Developer mode** (top‑right).

--- a/background.js
+++ b/background.js
@@ -1,5 +1,37 @@
 // background.js (drop-in)
 
+function sanitize(str) {
+  return (str || '')
+    .replace(/[\\/:*?"<>|]/g, '')
+    .trim()
+    .replace(/\s+/g, '_');
+}
+
+function formatTimestamp(fmt) {
+  const d = new Date();
+  const pad = (n, l = 2) => String(n).padStart(l, '0');
+  const Y = pad(d.getFullYear(), 4);
+  const M = pad(d.getMonth() + 1);
+  const D = pad(d.getDate());
+  const h = pad(d.getHours());
+  const m = pad(d.getMinutes());
+  const s = pad(d.getSeconds());
+  switch (fmt) {
+    case 'YYYYMMDD_HHMMSS':
+      return `${Y}${M}${D}_${h}${m}${s}`;
+    case 'YYYYMMDD_HHMM':
+      return `${Y}${M}${D}_${h}${m}`;
+    case 'YYYYMMDD':
+      return `${Y}${M}${D}`;
+    case 'YYYY-MM-DD_HHMMSS':
+      return `${Y}-${M}-${D}_${h}${m}${s}`;
+    case 'YYYY-MM-DD':
+      return `${Y}-${M}-${D}`;
+    default:
+      return '';
+  }
+}
+
 async function saveMHTML(tabId) {
   if (!tabId) return;
   try {
@@ -20,10 +52,35 @@ async function saveMHTML(tabId) {
     }
     const base64 = btoa(binary);
     const dataUrl = `data:application/x-mimearchive;base64,${base64}`;
-    const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+
+    const tab = await chrome.tabs.get(tabId);
+    const opts = await new Promise(r => chrome.storage.local.get({
+      filenameBase: 'title',
+      customFilename: '',
+      timestampFormat: 'YYYYMMDD_HHMMSS'
+    }, r));
+    let baseName = '';
+    switch (opts.filenameBase) {
+      case 'url':
+        baseName = sanitize(tab.url);
+        break;
+      case 'domain':
+        try { baseName = sanitize(new URL(tab.url).hostname); } catch { baseName = ''; }
+        break;
+      case 'custom':
+        baseName = sanitize(opts.customFilename) || 'archive';
+        break;
+      case 'title':
+      default:
+        baseName = sanitize(tab.title) || 'archive';
+        break;
+    }
+    const ts = formatTimestamp(opts.timestampFormat);
+    const filename = `${baseName}${ts ? '_' + ts : ''}.mhtml`;
+
     const downloadId = await chrome.downloads.download({
       url: dataUrl,
-      filename: `civitai-archive-${stamp}.mhtml`,
+      filename,
       saveAs: true
     });
 

--- a/options.html
+++ b/options.html
@@ -23,6 +23,22 @@
       <label>Scroll delay (ms): <input id="scrollDelay" type="number" min="50" max="5000" step="50"></label>
       <label>Stability timeout (ms): <input id="stabilityTimeout" type="number" min="100" max="5000" step="100"></label>
     </div>
+    <div>
+      <p>Filename base:</p>
+      <label><input type="radio" name="filenameBase" value="title" checked> Browser tab title</label>
+      <label><input type="radio" name="filenameBase" value="url"> Website URL</label>
+      <label><input type="radio" name="filenameBase" value="domain"> Domain name only</label>
+      <label><input type="radio" name="filenameBase" value="custom"> Custom: <input id="customFilename" type="text"></label>
+    </div>
+    <div>
+      <p>Timestamp format:</p>
+      <label><input type="radio" name="timestampFormat" value="none"> No time stamp</label>
+      <label><input type="radio" name="timestampFormat" value="YYYYMMDD_HHMMSS" checked> YYYYMMDD_HHMMSS</label>
+      <label><input type="radio" name="timestampFormat" value="YYYYMMDD_HHMM"> YYYYMMDD_HHMM</label>
+      <label><input type="radio" name="timestampFormat" value="YYYYMMDD"> YYYYMMDD</label>
+      <label><input type="radio" name="timestampFormat" value="YYYY-MM-DD_HHMMSS"> YYYY-MM-DD_HHMMSS</label>
+      <label><input type="radio" name="timestampFormat" value="YYYY-MM-DD"> YYYY-MM-DD</label>
+    </div>
     <button id="save">Save</button>
     <div id="status"></div>
     <script src="options.js"></script>

--- a/options.js
+++ b/options.js
@@ -1,10 +1,19 @@
 function restoreOptions() {
   chrome.storage.local.get({
     scrollDelay: 300,
-    stabilityTimeout: 400
+    stabilityTimeout: 400,
+    filenameBase: 'title',
+    customFilename: '',
+    timestampFormat: 'YYYYMMDD_HHMMSS'
   }, opts => {
     document.getElementById('scrollDelay').value = opts.scrollDelay;
     document.getElementById('stabilityTimeout').value = opts.stabilityTimeout;
+    const baseRadio = document.querySelector(`input[name="filenameBase"][value="${opts.filenameBase}"]`);
+    if (baseRadio) baseRadio.checked = true;
+    document.getElementById('customFilename').value = opts.customFilename || '';
+    document.getElementById('customFilename').disabled = opts.filenameBase !== 'custom';
+    const tsRadio = document.querySelector(`input[name="timestampFormat"][value="${opts.timestampFormat}"]`);
+    if (tsRadio) tsRadio.checked = true;
   });
 
   chrome.commands.getAll(commands => {
@@ -23,13 +32,16 @@ function saveOptions() {
   const resetShortcut = document.getElementById('resetShortcut').value || 'Alt+Shift+R';
   const scrollDelay = parseInt(document.getElementById('scrollDelay').value || '300', 10);
   const stabilityTimeout = parseInt(document.getElementById('stabilityTimeout').value || '400', 10);
+  const filenameBase = document.querySelector('input[name="filenameBase"]:checked')?.value || 'title';
+  const customFilename = document.getElementById('customFilename').value || '';
+  const timestampFormat = document.querySelector('input[name="timestampFormat"]:checked')?.value || 'YYYYMMDD_HHMMSS';
 
   chrome.commands.update({ name: 'start', shortcut: startShortcut });
   chrome.commands.update({ name: 'save', shortcut: saveShortcut });
   chrome.commands.update({ name: 'startAndSave', shortcut: startSaveShortcut });
   chrome.commands.update({ name: 'reset', shortcut: resetShortcut });
 
-  chrome.storage.local.set({ scrollDelay, stabilityTimeout }, () => {
+  chrome.storage.local.set({ scrollDelay, stabilityTimeout, filenameBase, customFilename, timestampFormat }, () => {
     const status = document.getElementById('status');
     status.textContent = 'Options saved.';
     setTimeout(() => status.textContent = '', 1500);
@@ -39,3 +51,10 @@ function saveOptions() {
 document.getElementById('save').addEventListener('click', saveOptions);
 
 document.addEventListener('DOMContentLoaded', restoreOptions);
+
+document.querySelectorAll('input[name="filenameBase"]').forEach(r => {
+  r.addEventListener('change', () => {
+    const customInput = document.getElementById('customFilename');
+    customInput.disabled = document.querySelector('input[name="filenameBase"]:checked').value !== 'custom';
+  });
+});

--- a/options.js
+++ b/options.js
@@ -36,10 +36,20 @@ function saveOptions() {
   const customFilename = document.getElementById('customFilename').value || '';
   const timestampFormat = document.querySelector('input[name="timestampFormat"]:checked')?.value || 'YYYYMMDD_HHMMSS';
 
-  chrome.commands.update({ name: 'start', shortcut: startShortcut });
-  chrome.commands.update({ name: 'save', shortcut: saveShortcut });
-  chrome.commands.update({ name: 'startAndSave', shortcut: startSaveShortcut });
-  chrome.commands.update({ name: 'reset', shortcut: resetShortcut });
+  const updateShortcut = (name, shortcut) => {
+    if (chrome.commands && typeof chrome.commands.update === 'function') {
+      try {
+        chrome.commands.update({ name, shortcut });
+      } catch (e) {
+        console.warn('commands.update failed', e);
+      }
+    }
+  };
+
+  updateShortcut('start', startShortcut);
+  updateShortcut('save', saveShortcut);
+  updateShortcut('startAndSave', startSaveShortcut);
+  updateShortcut('reset', resetShortcut);
 
   chrome.storage.local.set({ scrollDelay, stabilityTimeout, filenameBase, customFilename, timestampFormat }, () => {
     const status = document.getElementById('status');

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -6,13 +6,15 @@ global.chrome = {
   action: { openPopup: jest.fn(() => Promise.resolve()) },
   tabs: {
     query: jest.fn(() => Promise.resolve([{ id: 321 }])),
+    get: jest.fn(() => Promise.resolve({ id: 321, title: 'My Tab', url: 'https://example.com/path' })),
     sendMessage,
     reload: jest.fn(),
   },
   pageCapture: { saveAsMHTML: jest.fn(() => Promise.resolve({ arrayBuffer: () => Promise.resolve(Uint8Array.from([116,101,115,116]).buffer) })) },
   downloads: { download: jest.fn(() => Promise.resolve(1)), onChanged: { addListener: jest.fn(), removeListener: jest.fn() } },
   runtime: { onMessage: { addListener: jest.fn() }, reload: jest.fn() },
-  commands: { onCommand: { addListener: jest.fn() } }
+  commands: { onCommand: { addListener: jest.fn() } },
+  storage: { local: { get: jest.fn((defaults, cb) => cb(defaults)) } }
 };
 
 require('../background.js');
@@ -49,5 +51,8 @@ test('save command opens popup then triggers download', async () => {
   expect(chrome.pageCapture.saveAsMHTML).toHaveBeenCalledWith({ tabId: 321 });
   const urlArg = chrome.downloads.download.mock.calls[0][0].url;
   expect(urlArg.startsWith('data:application/x-mimearchive;base64,')).toBe(true);
+  const fname = chrome.downloads.download.mock.calls[0][0].filename;
+  expect(fname.startsWith('My_Tab_')).toBe(true);
+  expect(fname.endsWith('.mhtml')).toBe(true);
 });
 

--- a/tests/options.test.js
+++ b/tests/options.test.js
@@ -1,0 +1,39 @@
+document.body.innerHTML = `
+  <input id="startShortcut" value="Alt+1" />
+  <input id="saveShortcut" value="Alt+2" />
+  <input id="startSaveShortcut" value="Alt+3" />
+  <input id="resetShortcut" value="Alt+Shift+R" />
+  <input id="scrollDelay" value="300" />
+  <input id="stabilityTimeout" value="400" />
+  <input type="radio" name="filenameBase" value="url" />
+  <input type="radio" name="filenameBase" value="custom" checked />
+  <input id="customFilename" value="my page" />
+  <input type="radio" name="timestampFormat" value="YYYYMMDD" checked />
+  <button id="save"></button>
+  <div id="status"></div>
+`;
+
+global.chrome = {
+  storage: { local: { get: jest.fn((defs, cb) => cb(defs)), set: jest.fn() } },
+  commands: { getAll: jest.fn(cb => cb([])) }
+};
+
+require('../options.js');
+
+document.dispatchEvent(new Event('DOMContentLoaded'));
+
+const customField = document.getElementById('customFilename');
+customField.disabled = false;
+customField.value = 'my page';
+
+document.getElementById('save').click();
+
+test('saves options without commands.update', () => {
+  expect(chrome.storage.local.set).toHaveBeenCalledWith({
+    scrollDelay: 300,
+    stabilityTimeout: 400,
+    filenameBase: 'custom',
+    customFilename: 'my page',
+    timestampFormat: 'YYYYMMDD'
+  }, expect.any(Function));
+});

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -19,7 +19,7 @@ global.URL.revokeObjectURL = jest.fn();
 
 global.chrome = {
   tabs: {
-    query: jest.fn(() => Promise.resolve([{ id: 123 }])),
+    query: jest.fn(() => Promise.resolve([{ id: 123, title: 'My Tab', url: 'https://example.com/page' }])),
     sendMessage: jest.fn(),
     reload: jest.fn()
   },
@@ -49,6 +49,9 @@ test('save button triggers page capture and download', async () => {
   const blobArg = global.URL.createObjectURL.mock.calls[0][0];
   expect(blobArg.type).toBe('application/x-mimearchive');
   expect(chrome.downloads.download).toHaveBeenCalled();
+  const fname = chrome.downloads.download.mock.calls[0][0].filename;
+  expect(fname.startsWith('My_Tab_')).toBe(true);
+  expect(fname.endsWith('.mhtml')).toBe(true);
 });
 
 test('reset button stops autoscroll, reloads the page and extension', async () => {


### PR DESCRIPTION
## Summary
- add options UI for filename base and timestamp formatting
- support custom filename logic when saving MHTML
- document configurable filename options

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b72d58b9e8832996fc71300d3801f7