### PR TITLE
Remember last download directory

### DIFF
--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -1,6 +1,7 @@
 global.btoa = str => Buffer.from(str, 'binary').toString('base64');
 
 const sendMessage = jest.fn(() => Promise.resolve());
+const store = {};
 
 global.chrome = {
   action: { openPopup: jest.fn(() => Promise.resolve()) },
@@ -11,10 +12,19 @@ global.chrome = {
     reload: jest.fn(),
   },
   pageCapture: { saveAsMHTML: jest.fn(() => Promise.resolve({ arrayBuffer: () => Promise.resolve(Uint8Array.from([116,101,115,116]).buffer) })) },
-  downloads: { download: jest.fn(() => Promise.resolve(1)), onChanged: { addListener: jest.fn(), removeListener: jest.fn() } },
+  downloads: {
+    download: jest.fn(() => Promise.resolve(1)),
+    search: jest.fn((query, cb) => cb([{ id: query.id, filename: '/tmp/path/file.mhtml' }])),
+    onChanged: { addListener: jest.fn(), removeListener: jest.fn() }
+  },
   runtime: { onMessage: { addListener: jest.fn() }, reload: jest.fn() },
   commands: { onCommand: { addListener: jest.fn() } },
-  storage: { local: { get: jest.fn((defaults, cb) => cb(defaults)) } }
+  storage: {
+    local: {
+      get: jest.fn((defaults, cb) => cb({ ...defaults, ...store })),
+      set: jest.fn((obj, cb) => { Object.assign(store, obj); cb && cb(); })
+    }
+  }
 };
 
 require('../background.js');
@@ -54,5 +64,24 @@ test('save command opens popup then triggers download', async () => {
   const fname = chrome.downloads.download.mock.calls[0][0].filename;
   expect(fname.startsWith('My_Tab_')).toBe(true);
   expect(fname.endsWith('.mhtml')).toBe(true);
+});
+
+test('stores and reuses last download directory', async () => {
+  Object.keys(store).forEach(k => delete store[k]);
+  store.useLastDir = true;
+  chrome.downloads.download.mockClear();
+  const handler = chrome.commands.onCommand.addListener.mock.calls[0][0];
+
+  await handler('save');
+  const listener = chrome.downloads.onChanged.addListener.mock.calls.pop()[0];
+  chrome.downloads.search.mockImplementation((q, cb) => cb([{ filename: '/dl/path/first.mhtml' }]));
+  listener({ id: 1, state: { current: 'complete' } });
+  expect(chrome.storage.local.set).toHaveBeenCalledWith({ lastDownloadDir: '/dl/path' });
+
+  chrome.downloads.download.mockClear();
+  await handler('save');
+  const opts = chrome.downloads.download.mock.calls[0][0];
+  expect(opts.saveAs).toBe(false);
+  expect(opts.filename.startsWith('/dl/path/')).toBe(true);
 });
 


### PR DESCRIPTION
## Summary
- track completed download directory and persist as `lastDownloadDir`
- reuse stored directory on subsequent downloads when `useLastDir` is enabled
- cover directory persistence and reuse with unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b74693323c8329a5dd7d0fe3008fac