### PR TITLE
Use page context save for keyboard shortcut and start-and-save

### DIFF
--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -1,6 +1,12 @@
 global.btoa = str => Buffer.from(str, 'binary').toString('base64');
+global.Blob = require('buffer').Blob;
+global.URL.createObjectURL = jest.fn(() => 'blob:fake');
+global.URL.revokeObjectURL = jest.fn();
 
-const sendMessage = jest.fn(() => Promise.resolve());
+const sendMessage = jest.fn((tabId, msg) => {
+  if (msg.type === 'ARCHIVER_SAVE_MHTML_VIA_PAGE') return Promise.resolve({ ok: true });
+  return Promise.resolve({});
+});
 
 global.chrome = {
   action: { openPopup: jest.fn(() => Promise.resolve()) },
@@ -10,7 +16,7 @@ global.chrome = {
     sendMessage,
     reload: jest.fn(),
   },
-  pageCapture: { saveAsMHTML: jest.fn(() => Promise.resolve({ arrayBuffer: () => Promise.resolve(Uint8Array.from([116,101,115,116]).buffer) })) },
+  pageCapture: { saveAsMHTML: jest.fn(() => Promise.resolve(new Blob(['test'], { type: 'text/plain' }))) },
   downloads: { download: jest.fn(() => Promise.resolve(1)), onChanged: { addListener: jest.fn(), removeListener: jest.fn() } },
   runtime: { onMessage: { addListener: jest.fn() }, reload: jest.fn() },
   commands: { onCommand: { addListener: jest.fn() } },
@@ -41,18 +47,33 @@ test('reset command opens popup then reloads tab and extension', async () => {
   expect(chrome.runtime.reload).toHaveBeenCalled();
 });
 
-test('save command opens popup then triggers download', async () => {
+test('save command opens popup then saves via page context', async () => {
   chrome.action.openPopup.mockClear();
   chrome.pageCapture.saveAsMHTML.mockClear();
+  chrome.tabs.sendMessage.mockClear();
+  chrome.downloads.download.mockClear();
   const handler = chrome.commands.onCommand.addListener.mock.calls[0][0];
   await handler('save');
 
   expect(chrome.action.openPopup).toHaveBeenCalled();
   expect(chrome.pageCapture.saveAsMHTML).toHaveBeenCalledWith({ tabId: 321 });
-  const urlArg = chrome.downloads.download.mock.calls[0][0].url;
-  expect(urlArg.startsWith('data:application/x-mimearchive;base64,')).toBe(true);
-  const fname = chrome.downloads.download.mock.calls[0][0].filename;
+
+  const calls = chrome.tabs.sendMessage.mock.calls;
+  const prepareCall = calls.find(([, msg]) => msg.type === 'ARCHIVER_PREPARE_FOR_SAVE');
+  expect(prepareCall).toBeTruthy();
+
+  const saveCall = calls.find(([, msg]) => msg.type === 'ARCHIVER_SAVE_MHTML_VIA_PAGE');
+  expect(saveCall).toBeTruthy();
+  expect(saveCall[0]).toBe(321);
+  expect(saveCall[1].payload.blobUrl).toBe('blob:fake');
+  expect(saveCall[1].payload.mime).toBe('application/x-mimearchive');
+  const fname = saveCall[1].payload.suggestedName;
   expect(fname.startsWith('My_Tab_')).toBe(true);
   expect(fname.endsWith('.mhtml')).toBe(true);
+
+  const stopCall = calls.find(([, msg]) => msg.type === 'ARCHIVER_STOP');
+  expect(stopCall).toBeTruthy();
+
+  expect(chrome.downloads.download).not.toHaveBeenCalled();
 });
 


### PR DESCRIPTION
## Summary
- Save from background using in-page anchor so Alt-2 shortcut and start-and-save respect last-used folder
- Add tests ensuring page-context saving is invoked and downloads API is only a fallback

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc9771bb7c832995ebfe964eaf7e7b