### PR TITLE
feat: add save all tabs button

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -27,6 +27,9 @@
       <span class="button-wrapper"><span id="startSaveShortcutLabel" class="shortcut"></span><button id="startSave">Start and Save</button></span>
     </div>
     <div class="row buttons">
+      <span class="button-wrapper"><button id="saveAllTabs">Save all tabs</button></span>
+    </div>
+    <div class="row buttons">
       <span class="button-wrapper"><span id="resetShortcutLabel" class="shortcut"></span><button id="reset">Reset</button></span>
       <span class="button-wrapper"><button id="stop">Stop</button></span>
     </div>


### PR DESCRIPTION
## Summary
- add Save all tabs button to popup
- allow popup save logic to target specific tab IDs
- wire button to run MHTML save on every tab in current window

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bca6bbfd088329aa3dc80a780b8096