### PR TITLE
Freeze standalone videos before saving

### DIFF
--- a/content/archiver.js
+++ b/content/archiver.js
@@ -477,7 +477,7 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
         img.alt = 'Video snapshot';
 
         const loaded = await finalizeIfGood(img);
-        if (!loaded) { fail++; continue; }
+        if (!loaded) fail++;
 
         // Keep sizing consistent with the original gallery cards
         img.style.width = '100%';
@@ -522,7 +522,7 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
         img.alt = 'Video snapshot';
 
         const loaded = await finalizeIfGood(img);
-        if (!loaded) { fail++; continue; }
+        if (!loaded) fail++;
 
         const cs = getComputedStyle(v);
         img.style.width = cs.width;

--- a/content/archiver.js
+++ b/content/archiver.js
@@ -466,15 +466,26 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
         const img = document.createElement('img');
         img.src = still;
         img.alt = 'Video snapshot';
+
+        const loaded = await finalizeIfGood(img);
+        if (!loaded) { fail++; continue; }
+
         // Keep sizing consistent with the original gallery cards
         img.style.width = '100%';
         img.style.height = '100%';
         img.style.objectFit = 'cover';
         img.style.display = 'block';
+        img.dataset.archiverFrozen = '1';
+
+        // Strip sources to avoid embedding videos
+        v.pause?.();
+        v.removeAttribute('src');
+        v.removeAttribute('poster');
+        v.querySelectorAll('source').forEach(s => s.remove());
+        v.load?.();
 
         // Replace the <video> in place; anchor/href stays intact
         v.replaceWith(img);
-        v.dataset.archiverFrozen = '1';
         ok++;
       } catch (e) {
         fail++;
@@ -501,6 +512,9 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
         img.src = still;
         img.alt = 'Video snapshot';
 
+        const loaded = await finalizeIfGood(img);
+        if (!loaded) { fail++; continue; }
+
         const cs = getComputedStyle(v);
         img.style.width = cs.width;
         img.style.height = cs.height;
@@ -508,8 +522,15 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
         img.style.maxHeight = cs.maxHeight;
         img.style.objectFit = cs.objectFit;
         img.style.display = cs.display;
-
         img.dataset.archiverFrozen = '1';
+
+        // Strip sources to avoid embedding videos
+        v.pause?.();
+        v.removeAttribute('src');
+        v.removeAttribute('poster');
+        v.querySelectorAll('source').forEach(s => s.remove());
+        v.load?.();
+
         v.replaceWith(img);
         ok++;
       } catch (e) {

--- a/content/archiver.js
+++ b/content/archiver.js
@@ -543,7 +543,13 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
 
   // Message hook: popup will ask us to prepare the DOM before saving
   chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
-    if (msg && msg.type === 'ARCHIVER_PREPARE_FOR_SAVE') {
+    if (!msg) return;
+    if (msg.type === 'ARCHIVER_HAS_UNFROZEN_VIDEOS') {
+      const count = document.querySelectorAll('video:not([data-archiver-frozen])').length;
+      sendResponse({ count });
+      return;
+    }
+    if (msg.type === 'ARCHIVER_PREPARE_FOR_SAVE') {
       (async () => {
         try {
           const s1 = await freezeVideosInPlace();

--- a/content/archiver.js
+++ b/content/archiver.js
@@ -487,7 +487,7 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     if (videoEl.poster) {
       const dataUrl = await imageURLToDataURL(videoEl.poster);
       if (dataUrl) return dataUrl;
-      return videoEl.poster;
+      // If the poster can't be inlined fall through to frame capture
     }
 
     // 2) Otherwise try to grab a frame from an actual source
@@ -519,8 +519,6 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
       processed++;
       try {
         const still = await videoToStillURL(v);
-        if (!still) { skipped++; continue; }
-
         const img = document.createElement('img');
         img.alt = 'Video snapshot';
 
@@ -540,11 +538,14 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
         // Replace the <video> in place; anchor/href stays intact
         v.replaceWith(img);
 
-        img.src = still;
-        const loaded = await finalizeIfGood(img);
-        if (!loaded) fail++;
+        if (still) {
+          img.src = still;
+          const loaded = await finalizeIfGood(img);
+          if (loaded) ok++; else fail++;
+        } else {
+          fail++;
+        }
         img.dataset.archiverFrozen = '1';
-        ok++;
       } catch (e) {
         fail++;
       }
@@ -564,7 +565,6 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
       processed++;
       try {
         const still = await videoToStillURL(v);
-        if (!still) { skipped++; continue; }
 
         const cs = getComputedStyle(v);
         const img = document.createElement('img');
@@ -585,11 +585,14 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
 
         v.replaceWith(img);
 
-        img.src = still;
-        const loaded = await finalizeIfGood(img);
-        if (!loaded) fail++;
+        if (still) {
+          img.src = still;
+          const loaded = await finalizeIfGood(img);
+          if (loaded) ok++; else fail++;
+        } else {
+          fail++;
+        }
         img.dataset.archiverFrozen = '1';
-        ok++;
       } catch (e) {
         fail++;
       }

--- a/content/archiver.js
+++ b/content/archiver.js
@@ -403,11 +403,14 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     });
   }
 
-  // Fetch an image URL and return a data URL. Returns '' on failure.
+  // Fetch an image URL and return a data URL. Returns '' on failure or if the
+  // response is clearly not an image (some "poster" URLs return the original
+  // video instead, which bloats the save if converted to data: URIs).
   async function imageURLToDataURL(url) {
     try {
       const res = await fetch(url, { credentials: 'omit' });
       const blob = await res.blob();
+      if (!blob.type.startsWith('image/')) return '';
       return await new Promise((resolve) => {
         const fr = new FileReader();
         fr.onload = () => resolve(fr.result);

--- a/content/archiver.js
+++ b/content/archiver.js
@@ -393,6 +393,7 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
 // ------------------------------------------------------------
 (function () {
   const A_IMG_PAGE = 'a[href*="/images/"], a[href^="/images/"]';
+  const TRANSPARENT_PX = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
 
   function finalizeIfGood(imgEl) {
     return new Promise((resolve) => {
@@ -459,7 +460,7 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
       v.src = src;
 
       await new Promise((res, rej) => {
-        const to = setTimeout(() => rej(new Error('video load timeout')), 4000);
+        const to = setTimeout(() => rej(new Error('video load timeout')), 1000);
         v.addEventListener('loadeddata', () => { clearTimeout(to); res(); }, { once: true });
         v.addEventListener('error', () => { clearTimeout(to); rej(new Error('video load error')); }, { once: true });
       });
@@ -538,13 +539,9 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
         // Replace the <video> in place; anchor/href stays intact
         v.replaceWith(img);
 
-        if (still) {
-          img.src = still;
-          const loaded = await finalizeIfGood(img);
-          if (loaded) ok++; else fail++;
-        } else {
-          fail++;
-        }
+        img.src = still || TRANSPARENT_PX;
+        const loaded = await finalizeIfGood(img);
+        if (still && loaded) ok++; else fail++;
         img.dataset.archiverFrozen = '1';
       } catch (e) {
         fail++;
@@ -585,13 +582,9 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
 
         v.replaceWith(img);
 
-        if (still) {
-          img.src = still;
-          const loaded = await finalizeIfGood(img);
-          if (loaded) ok++; else fail++;
-        } else {
-          fail++;
-        }
+        img.src = still || TRANSPARENT_PX;
+        const loaded = await finalizeIfGood(img);
+        if (still && loaded) ok++; else fail++;
         img.dataset.archiverFrozen = '1';
       } catch (e) {
         fail++;

--- a/popup.js
+++ b/popup.js
@@ -67,6 +67,7 @@ async function waitForVideosFrozen(tabId, timeoutMs = 4000) {
     try {
       const res = await sendToContent('ARCHIVER_HAS_UNFROZEN_VIDEOS', {}, tabId);
       if (!res || res.count === 0) return;
+      await sendToContent('ARCHIVER_PREPARE_FOR_SAVE', {}, tabId);
     } catch (_) {
       return; // no listener or other error
     }


### PR DESCRIPTION
## Summary
- Handle standalone `/images/...` pages by converting videos to still images before saving
- Merge standalone and gallery video freezing stats when preparing for save

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcb53f94f883298ca38623763272ee