### PR TITLE
Handle capture permission errors when saving all tabs

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -163,11 +163,11 @@ async function doSaveAllTabs() {
     const tabs = await chrome.tabs.query({ currentWindow: true });
     for (const tab of tabs) {
       if (!tab.url || !/^https?:/i.test(tab.url)) {
-        console.warn('[GA][POPUP] Skipping unsupported URL', tab.id, tab.url);
+        console.debug('[GA][POPUP] Skipping unsupported URL', tab.id, tab.url || '(no url)');
         continue;
       }
       if (!(await hasCapturePermission(tab))) {
-        console.warn('[GA][POPUP] Skipping tab without permissions', tab.id, tab.url);
+        console.debug('[GA][POPUP] Skipping tab without permissions', tab.id, tab.url || '(no url)');
         continue;
       }
       try {

--- a/popup.js
+++ b/popup.js
@@ -80,6 +80,20 @@ async function waitForVideosFrozen(tabId, timeoutMs = 1000) {
   }
 }
 
+async function hasCapturePermission(tab) {
+  try {
+    const url = new URL(tab.url);
+    const originPattern = `${url.origin}/*`;
+    return await new Promise((resolve) => {
+      chrome.permissions.contains({ origins: [originPattern] }, (granted) => {
+        resolve(Boolean(granted));
+      });
+    });
+  } catch {
+    return false;
+  }
+}
+
 function restoreOptions() {
   chrome.storage.local.get({ maxItems: 200 }, (opts) => {
     const el = document.getElementById('maxItems');
@@ -148,6 +162,14 @@ async function doSaveAllTabs() {
   try {
     const tabs = await chrome.tabs.query({ currentWindow: true });
     for (const tab of tabs) {
+      if (!tab.url || !/^https?:/i.test(tab.url)) {
+        console.warn('[GA][POPUP] Skipping unsupported URL', tab.id, tab.url);
+        continue;
+      }
+      if (!(await hasCapturePermission(tab))) {
+        console.warn('[GA][POPUP] Skipping tab without permissions', tab.id, tab.url);
+        continue;
+      }
       try {
         await doSaveInPage(tab);
       } catch (err) {

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -154,6 +154,25 @@ test('saveAllTabs skips tabs without permissions', async () => {
   expect(saveCalls[0][0]).toBe(1);
 });
 
+test('saveAllTabs skips tabs with unsupported URLs', async () => {
+  chrome.pageCapture.saveAsMHTML.mockClear();
+  chrome.tabs.sendMessage.mockClear();
+  chrome.tabs.query.mockImplementationOnce(() => Promise.resolve([
+    { id: 1, title: 'Tab 1' },
+    { id: 2, title: 'Tab 2', url: 'https://example.com/2' }
+  ]));
+  document.getElementById('saveAllTabs').click();
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  await new Promise(r => setTimeout(r, 300));
+  expect(chrome.pageCapture.saveAsMHTML).toHaveBeenCalledTimes(1);
+  expect(chrome.pageCapture.saveAsMHTML).toHaveBeenCalledWith({ tabId: 2 });
+  const saveCalls = chrome.tabs.sendMessage.mock.calls.filter(([, msg]) => msg.type === 'ARCHIVER_SAVE_MHTML_VIA_PAGE');
+  expect(saveCalls.length).toBe(1);
+  expect(saveCalls[0][0]).toBe(2);
+});
+
 test('handles ARCHIVER_POPUP_SAVE_ALL_TABS message', async () => {
   chrome.pageCapture.saveAsMHTML.mockClear();
   chrome.tabs.sendMessage.mockClear();


### PR DESCRIPTION
## Summary
- check each tab's URL and permissions before attempting to save
- skip unsupported or unauthorized tabs instead of logging errors
- test save-all-tab behavior when some tabs lack permission

## Testing
- `npm test 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68bce4047560832982c809b1ebb8d6c9