### PR TITLE
Wrap standalone video replacements with anchor

### DIFF
--- a/content/archiver.js
+++ b/content/archiver.js
@@ -566,12 +566,19 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
         const cs = getComputedStyle(v);
         const img = document.createElement('img');
         img.alt = 'Video snapshot';
-        img.style.width = cs.width;
-        img.style.height = cs.height;
-        img.style.maxWidth = cs.maxWidth;
-        img.style.maxHeight = cs.maxHeight;
+        img.style.width = '100%';
+        img.style.height = '100%';
         img.style.objectFit = cs.objectFit;
-        img.style.display = cs.display;
+        img.style.display = 'block';
+
+        const a = document.createElement('a');
+        a.href = location.href;
+        a.style.width = cs.width;
+        a.style.height = cs.height;
+        a.style.maxWidth = cs.maxWidth;
+        a.style.maxHeight = cs.maxHeight;
+        a.style.display = cs.display;
+        a.appendChild(img);
 
         // Strip sources to avoid embedding videos
         v.pause?.();
@@ -580,7 +587,7 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
         v.querySelectorAll('source').forEach(s => s.remove());
         v.load?.();
 
-        v.replaceWith(img);
+        v.replaceWith(a);
 
         img.src = still || TRANSPARENT_PX;
         const loaded = await finalizeIfGood(img);
@@ -625,6 +632,10 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
 
   // Optional debug helper (run in console if needed):
   //   window.__archiverFreezeVideos = freezeVideosInPlace;
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports.freezeStandaloneVideos = freezeStandaloneVideos;
+  }
 })();
 
 /* ------------------------------------------------------------------

--- a/tests/freezeStandaloneVideos.test.js
+++ b/tests/freezeStandaloneVideos.test.js
@@ -1,0 +1,45 @@
+let freezeStandaloneVideos;
+
+beforeAll(() => {
+  global.chrome = {
+    runtime: { onMessage: { addListener: jest.fn() }, sendMessage: jest.fn() },
+    storage: { local: { get: jest.fn() } },
+  };
+  ({ freezeStandaloneVideos } = require('../content/archiver.js'));
+});
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+test('freezes standalone video into anchored snapshot', async () => {
+  // Simulate being on an image detail page
+  window.history.replaceState({}, '', 'http://localhost/images/123');
+
+  const v = document.createElement('video');
+  v.setAttribute('poster', 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==');
+  v.style.width = '320px';
+  v.style.height = '180px';
+  document.body.appendChild(v);
+
+  const desc = Object.getOwnPropertyDescriptor(HTMLImageElement.prototype, 'src');
+  Object.defineProperty(HTMLImageElement.prototype, 'src', {
+    configurable: true,
+    get: function() { return desc && desc.get ? desc.get.call(this) : undefined; },
+    set: function(val) {
+      if (desc && desc.set) desc.set.call(this, val); else this.setAttribute('src', val);
+      setTimeout(() => this.dispatchEvent(new Event('load')));
+    }
+  });
+
+  await freezeStandaloneVideos();
+
+  Object.defineProperty(HTMLImageElement.prototype, 'src', desc);
+
+  const anchor = document.querySelector('a');
+  expect(anchor).not.toBeNull();
+  expect(anchor.href).toBe(window.location.href);
+  const img = anchor.querySelector('img');
+  expect(img).not.toBeNull();
+  expect(img.dataset.archiverFrozen).toBe('1');
+});


### PR DESCRIPTION
## Summary
- Wrap frozen standalone `<video>` elements in an `<a>` linking to the current page and keep layout sizing.
- Expose `freezeStandaloneVideos` for tests and mark the generated `<img>` with `data-archiver-frozen`.
- Add unit test ensuring standalone videos are replaced with an anchor-wrapped snapshot.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bda18d6dc08329979d151c2fd01642