### PR TITLE
Freeze gallery styles during save

### DIFF
--- a/content/archiver.js
+++ b/content/archiver.js
@@ -705,25 +705,21 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     const container = root.querySelector('.mantine-Container-root, .mantine-container, [class*="Container-root"]');
     const grid = root.querySelector('.mantine-SimpleGrid-root, [class*="SimpleGrid-root"], [class*="simpleGrid"]');
 
-    const els = new Set([root, header, container, grid]);
-
-    const lock = (el) => {
+    const apply = (el, props) => {
       if (!el) return;
       if (!el.hasAttribute('data-archiver-style')) {
         el.setAttribute('data-archiver-style', el.getAttribute('style') || '');
       }
       const cs = getComputedStyle(el);
-      for (const prop of cs) {
-        try {
-          const v = cs.getPropertyValue(prop);
-          if (v) el.style.setProperty(prop, v);
-        } catch (_) {
-          /* ignore */
-        }
+      for (const prop of props) {
+        const v = cs.getPropertyValue(prop);
+        if (v) el.style.setProperty(prop, v);
       }
     };
 
-    els.forEach(lock);
+    apply(header, ['height', 'margin-top', 'margin-bottom', 'padding-top', 'padding-bottom', 'z-index']);
+    apply(container, ['padding-top', 'padding-bottom', 'margin-top', 'margin-bottom', 'width', 'max-width']);
+    apply(grid, ['display', 'grid-template-columns', 'grid-auto-rows', 'grid-auto-columns', 'gap', 'row-gap', 'column-gap']);
   }
 
   function restoreGalleryStyles() {

--- a/content/archiver.js
+++ b/content/archiver.js
@@ -705,21 +705,25 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     const container = root.querySelector('.mantine-Container-root, .mantine-container, [class*="Container-root"]');
     const grid = root.querySelector('.mantine-SimpleGrid-root, [class*="SimpleGrid-root"], [class*="simpleGrid"]');
 
-    const lock = (el, props) => {
+    const els = new Set([root, header, container, grid]);
+
+    const lock = (el) => {
       if (!el) return;
       if (!el.hasAttribute('data-archiver-style')) {
         el.setAttribute('data-archiver-style', el.getAttribute('style') || '');
       }
       const cs = getComputedStyle(el);
-      props.forEach(p => {
-        const v = cs[p];
-        if (v) el.style[p] = v;
-      });
+      for (const prop of cs) {
+        try {
+          const v = cs.getPropertyValue(prop);
+          if (v) el.style.setProperty(prop, v);
+        } catch (_) {
+          /* ignore */
+        }
+      }
     };
 
-    lock(header, ['height', 'paddingTop', 'paddingBottom']);
-    lock(container, ['height', 'paddingTop', 'paddingBottom']);
-    lock(grid, ['gridTemplateColumns', 'gap']);
+    els.forEach(lock);
   }
 
   function restoreGalleryStyles() {


### PR DESCRIPTION
## Summary
- Add `freezeGalleryStyles` to snapshot computed layout values and tag modified nodes
- Add `restoreGalleryStyles` and invoke during stop and navigation
- Freeze gallery styles in ARCHIVER_PREPARE_FOR_SAVE with a short delay

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0ea88f4f08329b5b95a66394b3c66