### PR TITLE
feat: add tensor.art adapter support

### DIFF
--- a/content/archiver.js
+++ b/content/archiver.js
@@ -295,24 +295,26 @@
   }
 
   async function inlineFromCandidates(candidates) {
+    let fallbackSrc = '';
     for (const src of candidates || []) {
       if (!src || isTinyDataURI(src)) continue;
+      if (!fallbackSrc) fallbackSrc = src;
       const dataUrl = await fetchImageAsDataURL(src);
       if (dataUrl) {
         return { dataUrl, resolvedSrc: src };
       }
     }
-    return { dataUrl: '', resolvedSrc: '' };
+    return { dataUrl: '', resolvedSrc: fallbackSrc };
   }
 
   async function cloneImageToCache(img, { href = null, wrapIfNoHref = false } = {}) {
     const candidates = resolveImageUrlCandidates(img);
     if (!candidates.length) return false;
     const { dataUrl, resolvedSrc } = await inlineFromCandidates(candidates);
-    if (!dataUrl) return false;
+    if (!dataUrl && !resolvedSrc) return false;
     ensureCache();
     const clone = document.createElement('img');
-    clone.src = dataUrl;
+    clone.src = dataUrl || resolvedSrc;
     clone.alt = img.alt || '';
     clone.loading = 'eager';
     clone.decoding = 'sync';
@@ -334,10 +336,10 @@
     const poster = absUrl(video.poster || '');
     const src = absUrl(video.currentSrc || (video.querySelector('source') && video.querySelector('source').src) || '');
     const { dataUrl, resolvedSrc } = await inlineFromCandidates([poster, src]);
-    if (!dataUrl) return false;
+    if (!dataUrl && !resolvedSrc) return false;
     ensureCache();
     const clone = document.createElement('img');
-    clone.src = dataUrl;
+    clone.src = dataUrl || resolvedSrc || poster || src;
     clone.alt = video.getAttribute('aria-label') || video.getAttribute('title') || '';
     let node = clone;
     const linkHref = href || resolvedSrc || poster || src || '';
@@ -607,8 +609,18 @@
     window.__civitaiArchiverStart = startRunning;
     window.__civitaiArchiverStop = () => stopRunning(true);
 
+    if (typeof window !== 'undefined') {
+      window.__archiverUtils = {
+        absUrl,
+        pickBestFromSrcset,
+        isTinyDataURI,
+        resolveImageUrl,
+        resolveImageUrlCandidates,
+      };
+    }
+
     if (typeof module !== 'undefined' && module.exports) {
-      module.exports = { absUrl, pickBestFromSrcset, isTinyDataURI, resolveImageUrl };
+      module.exports = { absUrl, pickBestFromSrcset, isTinyDataURI, resolveImageUrl, resolveImageUrlCandidates };
     }
   })();
 
@@ -618,6 +630,60 @@
 (function () {
   const A_IMG_PAGE = 'a[href*="/images/"], a[href^="/images/"]';
   const TRANSPARENT_PX = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
+  const HOST = location.hostname.replace(/^www\./, '');
+
+  function getSharedUtils() {
+    if (typeof window === 'undefined') return {};
+    return window.__archiverUtils || {};
+  }
+
+  function resolveTensorArtImageUrl(img) {
+    const utils = getSharedUtils();
+    const resolver = utils.resolveImageUrlCandidates;
+    if (typeof resolver !== 'function') return '';
+    const candidates = resolver(img) || [];
+    for (const url of candidates) {
+      if (url) return url;
+    }
+    return '';
+  }
+
+  function cleanupTensorAttrs(img) {
+    if (!img) return;
+    ['loading', 'decoding', 'srcset', 'sizes'].forEach(attr => img.removeAttribute(attr));
+    [
+      'data-src',
+      'data-srcset',
+      'data-original',
+      'data-original-src',
+      'data-url',
+      'data-image-url',
+      'data-lazy-src',
+      'data-placeholder',
+      'data-rmiz-src',
+    ].forEach(attr => img.removeAttribute(attr));
+  }
+
+  function devirtualizeTensorArtImages() {
+    if (HOST !== 'tensor.art') return { processed: 0, updated: 0 };
+    const root = document.querySelector('main') || document.body;
+    if (!root) return { processed: 0, updated: 0 };
+    const imgs = Array.from(root.querySelectorAll('article img, div[data-index] img'));
+    let updated = 0;
+    for (const img of imgs) {
+      const url = resolveTensorArtImageUrl(img) || img.currentSrc || img.src || '';
+      if (!url) continue;
+      if (img.getAttribute('src') !== url) {
+        img.src = url;
+      }
+      cleanupTensorAttrs(img);
+      img.loading = 'eager';
+      img.decoding = 'sync';
+      img.referrerPolicy = img.referrerPolicy || 'no-referrer-when-downgrade';
+      updated++;
+    }
+    return { processed: imgs.length, updated };
+  }
 
   function finalizeIfGood(imgEl) {
     return new Promise((resolve) => {
@@ -840,6 +906,7 @@
     if (msg.type === 'ARCHIVER_PREPARE_FOR_SAVE') {
       (async () => {
         try {
+          const tensor = devirtualizeTensorArtImages();
           const s1 = await freezeVideosInPlace();
           const s2 = await freezeStandaloneVideos();
           const stats = {
@@ -849,7 +916,7 @@
             skipped:   (s1.skipped || 0) + (s2.skipped || 0),
             total:     (s1.total || 0) + (s2.total || 0),
           };
-          sendResponse({ ok: true, stats });
+          sendResponse({ ok: true, stats, tensor });
         } catch (e) {
           sendResponse({ ok: false, error: String(e) });
         }

--- a/content/archiver.js
+++ b/content/archiver.js
@@ -19,6 +19,50 @@
     return (candidates[0] && candidates[0].url) || img.currentSrc || img.src || null;
   }
 
+  function resolveImageUrl(img) {
+    if (!img) return '';
+    const candidates = [];
+    const seen = new Set();
+    const push = (url) => {
+      if (!url) return;
+      const resolved = absUrl(url);
+      if (!resolved || seen.has(resolved) || isTinyDataURI(resolved)) return;
+      seen.add(resolved);
+      candidates.push(resolved);
+    };
+
+    push(pickBestFromSrcset(img));
+    push(img.currentSrc);
+    push(img.getAttribute('src'));
+
+    const dataAttrs = [
+      'data-src',
+      'data-srcset',
+      'data-original-src',
+      'data-original',
+      'data-url',
+      'data-image-url',
+      'data-full',
+      'data-fullsrc',
+      'data-img-src',
+      'data-img',
+      'data-href',
+    ];
+    dataAttrs.forEach(name => push(img.getAttribute(name)));
+
+    Array.from(img.attributes || []).forEach(attr => {
+      if (/^data-(?:src|url)/i.test(attr.name)) push(attr.value);
+    });
+
+    const bg = img.style && img.style.backgroundImage;
+    if (bg) {
+      const m = bg.match(/url\(["']?(.*?)["']?\)/);
+      if (m) push(m[1]);
+    }
+
+    return candidates[0] || '';
+  }
+
   function isTinyDataURI(url) {
     return /^data:/.test(url || '') && (url || '').length < 1024;
   }
@@ -191,7 +235,7 @@
   }
 
   async function cloneImageToCache(img, { href = null, wrapIfNoHref = false } = {}) {
-    const src = absUrl(img.currentSrc || img.src || '');
+    const src = resolveImageUrl(img);
     if (!src || isTinyDataURI(src)) return false;
     const dataUrl = await fetchImageAsDataURL(src);
     if (!dataUrl) return false;
@@ -243,8 +287,8 @@
     if (!media) return null;
     if (media.href) return absUrl(media.href);
     if (media.imgEl) {
-      const src = media.imgEl.currentSrc || media.imgEl.src;
-      if (src) return absUrl(src);
+      const src = resolveImageUrl(media.imgEl);
+      if (src) return src;
     }
     if (media.videoEl) {
       const src = media.videoEl.poster || media.videoEl.currentSrc || (media.videoEl.querySelector('source') && media.videoEl.querySelector('source').src);
@@ -384,8 +428,8 @@
     state.scrollDelay = parseInt(opts.scrollDelay, 10) || 300;
     state.stabilityTimeout = parseInt(opts.stabilityTimeout, 10) || 400;
     document.querySelectorAll('img').forEach(img => {
-      const url = pickBestFromSrcset(img) || img.currentSrc || img.src;
-      if (url) state.allImageUrls.add(absUrl(url));
+      const url = resolveImageUrl(img);
+      if (url) state.allImageUrls.add(url);
     });
     postStats();
     postState();

--- a/content/archiver.js
+++ b/content/archiver.js
@@ -274,17 +274,24 @@
   async function fetchImageAsDataURL(url) {
     if (!url) return '';
     if (url.startsWith('data:')) return url;
-    try {
-      const res = await fetch(url, { credentials: 'include' });
-      if (!res.ok) throw new Error('bad status');
-      const blob = await res.blob();
-      const type = blob.type || '';
-      if (type && !type.startsWith('image/')) throw new Error('not image');
-      return await blobToDataURL(blob);
-    } catch (err) {
-      console.warn('[Archiver] failed to inline image', url, err);
-      return await imageToCanvasDataURL(url);
+
+    const credentialModes = ['omit', 'include'];
+    for (const cred of credentialModes) {
+      try {
+        const res = await fetch(url, cred === 'include' ? { credentials: 'include' } : undefined);
+        if (!res.ok) throw new Error(`bad status: ${res.status}`);
+        const blob = await res.blob();
+        const type = blob.type || '';
+        if (type && !type.startsWith('image/')) throw new Error('not image');
+        return await blobToDataURL(blob);
+      } catch (err) {
+        if (cred === credentialModes[credentialModes.length - 1]) {
+          console.warn('[Archiver] failed to inline image', url, err);
+        }
+      }
     }
+
+    return await imageToCanvasDataURL(url);
   }
 
   async function inlineFromCandidates(candidates) {
@@ -625,45 +632,49 @@
   // response is clearly not an image (some "poster" URLs return the original
   // video instead, which bloats the save if converted to data: URIs).
   async function imageURLToDataURL(url) {
-    // Attempt to fetch the poster so we can inline it. Some image CDN endpoints
-    // require cookies, so include credentials. If the response is not an image
-    // or the fetch fails, fall back to trying via an <img> element and canvas.
-    try {
-      const res = await fetch(url, { credentials: 'include' });
-      const blob = await res.blob();
-      if (!blob.type.startsWith('image/')) throw new Error('not image');
-      return await new Promise((resolve) => {
-        const fr = new FileReader();
-        fr.onload = () => resolve(fr.result);
-        fr.onerror = () => resolve('');
-        fr.readAsDataURL(blob);
-      });
-    } catch (_) {
-      // Fallback: load through an <img> and draw to canvas. This avoids CORS
-      // restrictions when the server allows it and lets us downscale/encode.
-      return await new Promise((resolve) => {
-        const img = new Image();
-        img.crossOrigin = 'anonymous';
-        img.onload = () => {
-          try {
-            let { width, height } = img;
-            const MAX_W = 512;
-            if (width > MAX_W) {
-              height = Math.round(height * (MAX_W / width));
-              width = MAX_W;
-            }
-            const c = document.createElement('canvas');
-            c.width = width; c.height = height;
-            c.getContext('2d').drawImage(img, 0, 0, width, height);
-            resolve(c.toDataURL('image/jpeg', 0.9));
-          } catch (_) {
-            resolve('');
-          }
-        };
-        img.onerror = () => resolve('');
-        img.src = url;
-      });
+    const credentialModes = ['omit', 'include'];
+    for (const cred of credentialModes) {
+      try {
+        const res = await fetch(url, cred === 'include' ? { credentials: 'include' } : undefined);
+        const blob = await res.blob();
+        if (!blob.type.startsWith('image/')) throw new Error('not image');
+        return await new Promise((resolve) => {
+          const fr = new FileReader();
+          fr.onload = () => resolve(fr.result);
+          fr.onerror = () => resolve('');
+          fr.readAsDataURL(blob);
+        });
+      } catch (err) {
+        if (cred === credentialModes[credentialModes.length - 1]) {
+          console.warn('[Archiver] failed to inline video poster', url, err);
+        }
+      }
     }
+
+    // Fallback: load through an <img> and draw to canvas. This avoids CORS
+    // restrictions when the server allows it and lets us downscale/encode.
+    return await new Promise((resolve) => {
+      const img = new Image();
+      img.crossOrigin = 'anonymous';
+      img.onload = () => {
+        try {
+          let { width, height } = img;
+          const MAX_W = 512;
+          if (width > MAX_W) {
+            height = Math.round(height * (MAX_W / width));
+            width = MAX_W;
+          }
+          const c = document.createElement('canvas');
+          c.width = width; c.height = height;
+          c.getContext('2d').drawImage(img, 0, 0, width, height);
+          resolve(c.toDataURL('image/jpeg', 0.9));
+        } catch (_) {
+          resolve('');
+        }
+      };
+      img.onerror = () => resolve('');
+      img.src = url;
+    });
   }
 
   // Try to capture a first frame if poster is missing and CORS allows

--- a/content/archiver.js
+++ b/content/archiver.js
@@ -7,20 +7,26 @@
     try { return new URL(href, location.origin).toString(); } catch { return href || ''; }
   }
 
-  function pickBestFromSrcset(img) {
-    const ss = img.getAttribute('srcset');
-    if (!ss) return img.currentSrc || img.src || null;
-    const candidates = ss.split(',').map(s => s.trim()).map(token => {
+  function srcsetUrls(img) {
+    const ss = img && img.getAttribute && img.getAttribute('srcset');
+    if (!ss) return [];
+    const parsed = ss.split(',').map(s => s.trim()).map(token => {
       const m = token.match(/^(.*)\s+(\d+)(w|x)$/);
-      if (m) return { url: absUrl(m[1].trim()), width: parseInt(m[2], 10), unit: m[3] };
-      return { url: absUrl(token.split(/\s+/)[0]), width: 0, unit: 'w' };
+      if (m) return { url: absUrl(m[1].trim()), width: parseInt(m[2], 10) };
+      return { url: absUrl(token.split(/\s+/)[0]), width: 0 };
     });
-    candidates.sort((a, b) => b.width - a.width);
-    return (candidates[0] && candidates[0].url) || img.currentSrc || img.src || null;
+    parsed.sort((a, b) => b.width - a.width);
+    return parsed.map(item => item.url).filter(Boolean);
   }
 
-  function resolveImageUrl(img) {
-    if (!img) return '';
+  function pickBestFromSrcset(img) {
+    const urls = srcsetUrls(img);
+    if (urls.length) return urls[0];
+    return (img && (img.currentSrc || img.src)) || null;
+  }
+
+  function resolveImageUrlCandidates(img) {
+    if (!img) return [];
     const candidates = [];
     const seen = new Set();
     const push = (url) => {
@@ -31,9 +37,9 @@
       candidates.push(resolved);
     };
 
-    push(pickBestFromSrcset(img));
     push(img.currentSrc);
-    push(img.getAttribute('src'));
+    if (img.getAttribute) push(img.getAttribute('src'));
+    srcsetUrls(img).forEach(push);
 
     const dataAttrs = [
       'data-src',
@@ -48,9 +54,9 @@
       'data-img',
       'data-href',
     ];
-    dataAttrs.forEach(name => push(img.getAttribute(name)));
+    dataAttrs.forEach(name => push(img.getAttribute && img.getAttribute(name)));
 
-    Array.from(img.attributes || []).forEach(attr => {
+    Array.from((img && img.attributes) || []).forEach(attr => {
       if (/^data-(?:src|url)/i.test(attr.name)) push(attr.value);
     });
 
@@ -60,7 +66,12 @@
       if (m) push(m[1]);
     }
 
-    return candidates[0] || '';
+    return candidates;
+  }
+
+  function resolveImageUrl(img) {
+    const [first] = resolveImageUrlCandidates(img);
+    return first || '';
   }
 
   function isTinyDataURI(url) {
@@ -276,10 +287,21 @@
     }
   }
 
+  async function inlineFromCandidates(candidates) {
+    for (const src of candidates || []) {
+      if (!src || isTinyDataURI(src)) continue;
+      const dataUrl = await fetchImageAsDataURL(src);
+      if (dataUrl) {
+        return { dataUrl, resolvedSrc: src };
+      }
+    }
+    return { dataUrl: '', resolvedSrc: '' };
+  }
+
   async function cloneImageToCache(img, { href = null, wrapIfNoHref = false } = {}) {
-    const src = resolveImageUrl(img);
-    if (!src || isTinyDataURI(src)) return false;
-    const dataUrl = await fetchImageAsDataURL(src);
+    const candidates = resolveImageUrlCandidates(img);
+    if (!candidates.length) return false;
+    const { dataUrl, resolvedSrc } = await inlineFromCandidates(candidates);
     if (!dataUrl) return false;
     ensureCache();
     const clone = document.createElement('img');
@@ -288,9 +310,10 @@
     clone.loading = 'eager';
     clone.decoding = 'sync';
     let node = clone;
-    if (!href && wrapIfNoHref && src) {
+    const linkHref = href || resolvedSrc || '';
+    if (!href && wrapIfNoHref && linkHref) {
       const a = document.createElement('a');
-      a.href = src;
+      a.href = linkHref;
       a.target = '_blank';
       a.rel = 'noopener noreferrer';
       a.appendChild(clone);
@@ -302,20 +325,18 @@
 
   async function cloneVideoToCache(video, { href = null, wrapIfNoHref = false } = {}) {
     const poster = absUrl(video.poster || '');
-    let dataUrl = poster ? await fetchImageAsDataURL(poster) : '';
-    if (!dataUrl) {
-      const src = absUrl(video.currentSrc || (video.querySelector('source') && video.querySelector('source').src) || '');
-      dataUrl = await fetchImageAsDataURL(src);
-    }
+    const src = absUrl(video.currentSrc || (video.querySelector('source') && video.querySelector('source').src) || '');
+    const { dataUrl, resolvedSrc } = await inlineFromCandidates([poster, src]);
     if (!dataUrl) return false;
     ensureCache();
     const clone = document.createElement('img');
     clone.src = dataUrl;
     clone.alt = video.getAttribute('aria-label') || video.getAttribute('title') || '';
     let node = clone;
-    if (!href && wrapIfNoHref && (poster || video.currentSrc)) {
+    const linkHref = href || resolvedSrc || poster || src || '';
+    if (!href && wrapIfNoHref && linkHref) {
       const a = document.createElement('a');
-      a.href = poster || video.currentSrc || '';
+      a.href = linkHref;
       a.target = '_blank';
       a.rel = 'noopener noreferrer';
       a.appendChild(clone);
@@ -471,7 +492,7 @@
     state.stabilityTimeout = parseInt(opts.stabilityTimeout, 10) || 400;
     document.querySelectorAll('img').forEach(img => {
       const url = resolveImageUrl(img);
-      if (url) state.allImageUrls.add(url);
+      if (url) state.allImageUrls.add(absUrl(url));
     });
     postStats();
     postState();
@@ -580,7 +601,7 @@
     window.__civitaiArchiverStop = () => stopRunning(true);
 
     if (typeof module !== 'undefined' && module.exports) {
-      module.exports = { absUrl, pickBestFromSrcset, isTinyDataURI };
+      module.exports = { absUrl, pickBestFromSrcset, isTinyDataURI, resolveImageUrl };
     }
   })();
 

--- a/content/archiver.js
+++ b/content/archiver.js
@@ -219,6 +219,47 @@
     });
   }
 
+  async function imageToCanvasDataURL(url) {
+    if (!url) return '';
+    return await new Promise((resolve) => {
+      try {
+        const img = new Image();
+        img.crossOrigin = 'anonymous';
+        img.decoding = 'sync';
+        img.loading = 'eager';
+        const cleanup = () => {
+          img.onload = null;
+          img.onerror = null;
+        };
+        img.onload = () => {
+          try {
+            const w = Math.max(1, img.naturalWidth || img.width || 0);
+            const h = Math.max(1, img.naturalHeight || img.height || 0);
+            const canvas = document.createElement('canvas');
+            canvas.width = w;
+            canvas.height = h;
+            const ctx = canvas.getContext('2d');
+            ctx.drawImage(img, 0, 0, w, h);
+            resolve(canvas.toDataURL('image/png'));
+          } catch (err) {
+            console.warn('[Archiver] canvas inline failed', url, err);
+            resolve('');
+          } finally {
+            cleanup();
+          }
+        };
+        img.onerror = () => {
+          cleanup();
+          resolve('');
+        };
+        img.src = url;
+      } catch (err) {
+        console.warn('[Archiver] image load failed', url, err);
+        resolve('');
+      }
+    });
+  }
+
   async function fetchImageAsDataURL(url) {
     if (!url) return '';
     if (url.startsWith('data:')) return url;
@@ -226,11 +267,12 @@
       const res = await fetch(url, { credentials: 'include' });
       if (!res.ok) throw new Error('bad status');
       const blob = await res.blob();
-      if (!blob.type.startsWith('image/')) throw new Error('not image');
+      const type = blob.type || '';
+      if (type && !type.startsWith('image/')) throw new Error('not image');
       return await blobToDataURL(blob);
     } catch (err) {
       console.warn('[Archiver] failed to inline image', url, err);
-      return '';
+      return await imageToCanvasDataURL(url);
     }
   }
 

--- a/content/archiver.js
+++ b/content/archiver.js
@@ -1,6 +1,121 @@
 /* Content script: core hoarding, anti-placeholder, auto-scroll, freeze */
 
 (() => {
+  const HOST = location.hostname.replace(/^www\./, '');
+
+  function absUrl(href) {
+    try { return new URL(href, location.origin).toString(); } catch { return href || ''; }
+  }
+
+  function pickBestFromSrcset(img) {
+    const ss = img.getAttribute('srcset');
+    if (!ss) return img.currentSrc || img.src || null;
+    const candidates = ss.split(',').map(s => s.trim()).map(token => {
+      const m = token.match(/^(.*)\s+(\d+)(w|x)$/);
+      if (m) return { url: absUrl(m[1].trim()), width: parseInt(m[2], 10), unit: m[3] };
+      return { url: absUrl(token.split(/\s+/)[0]), width: 0, unit: 'w' };
+    });
+    candidates.sort((a, b) => b.width - a.width);
+    return (candidates[0] && candidates[0].url) || img.currentSrc || img.src || null;
+  }
+
+  function isTinyDataURI(url) {
+    return /^data:/.test(url || '') && (url || '').length < 1024;
+  }
+
+  function getGalleryRootCivitai() {
+    const g = document.getElementById('gallery');
+    if (g) return g;
+    const anchors = Array.from(document.querySelectorAll('a[href*="/images/"], a[href^="/images/"]'));
+    if (!anchors.length) return document.body;
+    const sample = anchors.slice(0, 20);
+    const chains = sample.map(a => {
+      const list = [];
+      for (let n = a; n && n !== document.documentElement; n = n.parentElement) list.push(n);
+      return list;
+    });
+    for (const cand of chains[0] || []) {
+      if (chains.every(chain => chain.includes(cand))) return cand;
+    }
+    return document.getElementById('gallery') || document.body;
+  }
+
+  function selectCardsCivitai(root) {
+    const set = new Set();
+    root.querySelectorAll('a[href*="/images/"] img, a[href^="/images/"] img').forEach(img => {
+      const card = img.closest('a[href*="/images/"], a[href^="/images/"]') || img.parentElement;
+      if (card) set.add(card);
+    });
+    root.querySelectorAll('a[href*="/images/"], a[href^="/images/"]').forEach(a => set.add(a));
+    return Array.from(set);
+  }
+
+  function extractMediaFromCardCivitai(card) {
+    const anchorHref = card.getAttribute && card.getAttribute('href');
+    const img = card.querySelector('img');
+    if (img) {
+      return { type: 'image', imgEl: img, href: anchorHref ? absUrl(anchorHref) : null };
+    }
+    const video = card.querySelector('video');
+    if (video) {
+      return { type: 'video', videoEl: video, href: anchorHref ? absUrl(anchorHref) : null };
+    }
+    return null;
+  }
+
+  function getGalleryRootTensor() {
+    const imgs = Array.from(document.querySelectorAll('article img, div[data-index] img')).slice(0, 40);
+    if (!imgs.length) return document.querySelector('main') || document.body;
+    const cards = imgs.map(img => img.closest('article, div[data-index], [data-rmiz], .card, .group, .relative, .cursor-pointer'))
+      .filter(Boolean);
+    if (!cards.length) return document.querySelector('main') || document.body;
+    const chains = cards.map(n => {
+      const v = [];
+      for (let x = n; x && x !== document.documentElement; x = x.parentElement) v.push(x);
+      return v;
+    });
+    for (const cand of chains[0]) {
+      if (chains.every(chain => chain.includes(cand))) return cand;
+    }
+    return document.querySelector('main') || document.body;
+  }
+
+  function selectCardsTensor(root) {
+    const set = new Set();
+    root.querySelectorAll('article img, div[data-index] img').forEach(img => {
+      const card = img.closest('article, div[data-index]') || img.parentElement;
+      if (card) set.add(card);
+    });
+    return Array.from(set);
+  }
+
+  function extractMediaFromCardTensor(card) {
+    const img = card.querySelector('img');
+    if (img) return { type: 'image', imgEl: img, href: null };
+    const video = card.querySelector('video');
+    if (video) return { type: 'video', videoEl: video, href: null };
+    return null;
+  }
+
+  const adapterCivitai = {
+    getGalleryRoot: getGalleryRootCivitai,
+    selectCards: selectCardsCivitai,
+    extractMediaFromCard: extractMediaFromCardCivitai,
+  };
+
+  const adapterTensorArt = {
+    getGalleryRoot: getGalleryRootTensor,
+    selectCards: selectCardsTensor,
+    extractMediaFromCard: extractMediaFromCardTensor,
+  };
+
+  const adapters = {
+    'civitai.com': adapterCivitai,
+    'tensor.art': adapterTensorArt,
+  };
+
+  const ACTIVE_ADAPTER = adapters[HOST] || adapterCivitai;
+
   const state = {
     running: false,
     seen: 0,
@@ -9,33 +124,26 @@
     maxItems: 200,
     scrollDelay: 300,
     stabilityTimeout: 400,
-    items: new Map(), // key -> { detailUrl, imageUrl, el, state }
-    seenDetailUrls: new Set(), // dedupe by detail link
-    allImageUrls: new Set(), // every image destined for archive
+    items: new Map(),
+    allImageUrls: new Set(),
     observer: null,
     scrollTimer: null,
     lastNewItemAt: 0,
-    bucket: null,
+    cache: null,
     scrollEl: null,
     origHtmlStyle: '',
     origBodyStyle: '',
     autoSave: false,
+    adapter: ACTIVE_ADAPTER,
   };
 
-  const SEL_ANCHOR_IMG = 'a[href*="/images/"] img, a[href^="/images/"] img';
-  const SEL_ANCHOR_BG = 'a[href*="/images/"], a[href^="/images/"]';
-
-  function absUrl(href) {
-    try { return new URL(href, location.origin).toString(); } catch { return href; }
-  }
-
-  function ensureBucket() {
-    if (!state.bucket) {
-      const bucket = document.createElement('div');
-      bucket.id = 'civitai-archiver-bucket';
-      bucket.style.display = 'none';
-      document.body.appendChild(bucket);
-      state.bucket = bucket;
+  function ensureCache() {
+    if (!state.cache) {
+      const cache = document.createElement('div');
+      cache.id = 'archiver-cache';
+      cache.style.display = 'none';
+      document.body.appendChild(cache);
+      state.cache = cache;
     }
   }
 
@@ -45,7 +153,7 @@
       seen: state.seen,
       captured: state.captured,
       deduped: state.deduped,
-      total: state.allImageUrls.size
+      total: state.items.size
     });
   }
 
@@ -58,136 +166,146 @@
     });
   }
 
-  function pickBestFromSrcset(img) {
-    const ss = img.getAttribute('srcset');
-    if (!ss) return img.currentSrc || img.src || null;
-    // Parse candidates: "url widthDescriptor, url widthDescriptor, ..."
-    const candidates = ss.split(',').map(s => s.trim()).map(token => {
-      const m = token.match(/^(.*)\s+(\d+)(w|x)$/);
-      if (m) return { url: absUrl(m[1].trim()), width: parseInt(m[2], 10), unit: m[3] };
-      // fallback: might be just URL (rare); let width=0
-      return { url: absUrl(token.split(/\s+/)[0]), width: 0, unit: 'w' };
-    });
-    candidates.sort((a,b) => b.width - a.width);
-    return (candidates[0] && candidates[0].url) || img.currentSrc || img.src || null;
-  }
-
-  function isTinyDataURI(url) {
-    // Heuristic: data URI and short length (common for blurred placeholders)
-    return /^data:/.test(url) && url.length < 1024; // 1 KB threshold
-  }
-
-  // Ensure an image element is fully loaded
-
-  function finalizeIfGood(imgEl) {
-    return new Promise((resolve) => {
-      const done = () => resolve(true);
-      if (imgEl.complete && imgEl.naturalWidth > 0) return done();
-      imgEl.addEventListener('load', done, { once: true });
-      imgEl.addEventListener('error', () => resolve(false), { once: true });
+  async function blobToDataURL(blob) {
+    return await new Promise((resolve) => {
+      const fr = new FileReader();
+      fr.onload = () => resolve(fr.result);
+      fr.onerror = () => resolve('');
+      fr.readAsDataURL(blob);
     });
   }
 
-  function stabilityWatcher(targetEl, timeoutMs, onStable) {
-    let timer = null;
-    const mo = new MutationObserver(() => {
-      if (timer) clearTimeout(timer);
-      timer = setTimeout(() => {
-        mo.disconnect();
-        onStable();
-      }, timeoutMs);
-    });
-    mo.observe(targetEl, { attributes: true, attributeFilter: ['src', 'srcset', 'style', 'class'] });
-    // Kick off timer in case there are no changes after attach
-    timer = setTimeout(() => { mo.disconnect(); onStable(); }, timeoutMs);
+  async function fetchImageAsDataURL(url) {
+    if (!url) return '';
+    if (url.startsWith('data:')) return url;
+    try {
+      const res = await fetch(url, { credentials: 'include' });
+      if (!res.ok) throw new Error('bad status');
+      const blob = await res.blob();
+      if (!blob.type.startsWith('image/')) throw new Error('not image');
+      return await blobToDataURL(blob);
+    } catch (err) {
+      console.warn('[Archiver] failed to inline image', url, err);
+      return '';
+    }
   }
 
-  function processAnchorImg(anchor, img) {
+  async function cloneImageToCache(img, { href = null, wrapIfNoHref = false } = {}) {
+    const src = absUrl(img.currentSrc || img.src || '');
+    if (!src || isTinyDataURI(src)) return false;
+    const dataUrl = await fetchImageAsDataURL(src);
+    if (!dataUrl) return false;
+    ensureCache();
+    const clone = document.createElement('img');
+    clone.src = dataUrl;
+    clone.alt = img.alt || '';
+    clone.loading = 'eager';
+    clone.decoding = 'sync';
+    let node = clone;
+    if (!href && wrapIfNoHref && src) {
+      const a = document.createElement('a');
+      a.href = src;
+      a.target = '_blank';
+      a.rel = 'noopener noreferrer';
+      a.appendChild(clone);
+      node = a;
+    }
+    state.cache.appendChild(node);
+    return true;
+  }
+
+  async function cloneVideoToCache(video, { href = null, wrapIfNoHref = false } = {}) {
+    const poster = absUrl(video.poster || '');
+    let dataUrl = poster ? await fetchImageAsDataURL(poster) : '';
+    if (!dataUrl) {
+      const src = absUrl(video.currentSrc || (video.querySelector('source') && video.querySelector('source').src) || '');
+      dataUrl = await fetchImageAsDataURL(src);
+    }
+    if (!dataUrl) return false;
+    ensureCache();
+    const clone = document.createElement('img');
+    clone.src = dataUrl;
+    clone.alt = video.getAttribute('aria-label') || video.getAttribute('title') || '';
+    let node = clone;
+    if (!href && wrapIfNoHref && (poster || video.currentSrc)) {
+      const a = document.createElement('a');
+      a.href = poster || video.currentSrc || '';
+      a.target = '_blank';
+      a.rel = 'noopener noreferrer';
+      a.appendChild(clone);
+      node = a;
+    }
+    state.cache.appendChild(node);
+    return true;
+  }
+
+  function keyForMedia(media) {
+    if (!media) return null;
+    if (media.href) return absUrl(media.href);
+    if (media.imgEl) {
+      const src = media.imgEl.currentSrc || media.imgEl.src;
+      if (src) return absUrl(src);
+    }
+    if (media.videoEl) {
+      const src = media.videoEl.poster || media.videoEl.currentSrc || (media.videoEl.querySelector('source') && media.videoEl.querySelector('source').src);
+      if (src) return absUrl(src);
+    }
+    return null;
+  }
+
+  function processCard(card) {
     if (!state.running || state.captured >= state.maxItems) return;
-    const detailUrl = absUrl(anchor.getAttribute('href') || '');
-    if (!detailUrl) return;
+    const adapter = state.adapter || adapterCivitai;
+    const media = adapter.extractMediaFromCard(card);
+    if (!media) return;
+    const key = keyForMedia(media);
+    if (!key || state.items.has(key)) return;
 
-    if (state.seenDetailUrls.has(detailUrl)) return;
-    state.seenDetailUrls.add(detailUrl);
+    state.items.set(key, { type: media.type, status: 'pending' });
     state.seen++;
+    state.deduped = state.items.size;
+    postStats();
 
-    const initialUrl = pickBestFromSrcset(img) || img.src || '';
+    const wrapIfNoHref = !media.href;
+    const href = media.href ? absUrl(media.href) : null;
 
-    // Wait for image attributes to settle before cloning
-    stabilityWatcher(img, state.stabilityTimeout, async () => {
-      if (!state.running || state.captured >= state.maxItems) return;
-      const bestNow = pickBestFromSrcset(img) || img.src || initialUrl;
-      if (!bestNow || isTinyDataURI(bestNow)) return;
+    const task = media.type === 'video' && media.videoEl
+      ? cloneVideoToCache(media.videoEl, { href, wrapIfNoHref })
+      : media.imgEl
+        ? cloneImageToCache(media.imgEl, { href, wrapIfNoHref })
+        : Promise.resolve(false);
 
-      const cloneImg = document.createElement('img');
-      cloneImg.src = bestNow;
-      state.bucket.appendChild(cloneImg);
-      const ok = await finalizeIfGood(cloneImg);
-      if (!ok || !state.running) {
-        cloneImg.remove();
+    task.then(ok => {
+      if (!state.running) return;
+      if (!ok) {
+        state.items.delete(key);
+        state.deduped = state.items.size;
+        postStats();
         return;
       }
-
       state.captured++;
-      state.deduped = state.seenDetailUrls.size;
+      state.allImageUrls.add(key);
       state.lastNewItemAt = performance.now();
-      state.allImageUrls.add(absUrl(bestNow));
       postStats();
       postState();
-
       if (state.captured >= state.maxItems) stopRunning(false, false);
+    }).catch(err => {
+      console.warn('[Archiver] failed to clone media', err);
+      state.items.delete(key);
+      state.deduped = state.items.size;
+      postStats();
     });
-
-    postStats();
   }
 
   function scanOnce() {
     if (!state.running || state.captured >= state.maxItems) return;
-    ensureBucket();
-    // IMG-based cards
-    document.querySelectorAll(SEL_ANCHOR_IMG).forEach(img => {
+    ensureCache();
+    const adapter = state.adapter || adapterCivitai;
+    const root = (adapter.getGalleryRoot && adapter.getGalleryRoot()) || document.body;
+    const cards = (adapter.selectCards && adapter.selectCards(root)) || [];
+    cards.forEach(card => {
       if (state.captured >= state.maxItems) return;
-      const a = img.closest('a');
-      if (a) processAnchorImg(a, img);
-    });
-
-    // CSS background-image anchors (fallback)
-    document.querySelectorAll(SEL_ANCHOR_BG).forEach(a => {
-      if (state.captured >= state.maxItems) return;
-      const style = getComputedStyle(a);
-      const bg = style.backgroundImage;
-      if (bg && bg !== 'none') {
-        const m = bg.match(/url\(["']?(.*?)["']?\)/);
-        if (m && m[1]) {
-          const url = absUrl(m[1]);
-          const detailUrl = absUrl(a.getAttribute('href') || '');
-          if (!detailUrl || state.seenDetailUrls.has(detailUrl)) return;
-          if (state.captured >= state.maxItems) return;
-          state.seenDetailUrls.add(detailUrl);
-          state.seen++;
-
-          stabilityWatcher(a, state.stabilityTimeout, async () => {
-            if (!state.running || state.captured >= state.maxItems) return;
-            const cloneImg = document.createElement('img');
-            cloneImg.src = url;
-            state.bucket.appendChild(cloneImg);
-            const ok = await finalizeIfGood(cloneImg);
-            if (!ok || !state.running) {
-              cloneImg.remove();
-              return;
-            }
-            state.captured++;
-            state.deduped = state.seenDetailUrls.size;
-            state.lastNewItemAt = performance.now();
-            state.allImageUrls.add(absUrl(url));
-            postStats();
-            postState();
-            if (state.captured >= state.maxItems) stopRunning(false, false);
-          });
-
-          postStats();
-        }
-      }
+      processCard(card);
     });
   }
 
@@ -220,7 +338,6 @@
       scanOnce();
       if (!state.running) break;
 
-      // If no progress for a while, attempt a small nudge but keep looping
       const now = performance.now();
       if (state.captured > before) {
         state.lastNewItemAt = now;
@@ -246,39 +363,33 @@
   }
 
   function freezePage() {
-    ensureBucket();
-    // In earlier versions we hid the live app and revealed the bucket to create a
-    // static grid for the MHTML export. Now that the browser reliably captures
-    // the full page, keep the app visible and leave the bucket hidden so the
-    // saved archive doesn't include a duplicate grid.
+    ensureCache();
     restoreScrollStyles();
-    // Ensure bucket stays hidden
-    state.bucket.style.display = 'none';
+    if (state.cache) state.cache.style.display = 'none';
   }
 
   async function startRunning() {
     if (state.running) return;
+    state.adapter = ACTIVE_ADAPTER;
     state.running = true;
     state.seen = 0;
     state.captured = 0;
     state.deduped = 0;
-    state.seenDetailUrls.clear();
+    state.items = new Map();
     state.allImageUrls = new Set();
-    // Load options before starting capture
     const opts = await new Promise(resolve => {
-    chrome.storage.local.get({ maxItems: 200, scrollDelay: 300, stabilityTimeout: 400 }, resolve);
+      chrome.storage.local.get({ maxItems: 200, scrollDelay: 300, stabilityTimeout: 400 }, resolve);
     });
     state.maxItems = parseInt(opts.maxItems, 10) || 200;
     state.scrollDelay = parseInt(opts.scrollDelay, 10) || 300;
     state.stabilityTimeout = parseInt(opts.stabilityTimeout, 10) || 400;
-    // Collect any images already on the page
     document.querySelectorAll('img').forEach(img => {
       const url = pickBestFromSrcset(img) || img.currentSrc || img.src;
       if (url) state.allImageUrls.add(absUrl(url));
     });
     postStats();
     postState();
-    ensureBucket();
+    ensureCache();
     startObserver();
     state.scrollEl = getScrollElement();
     state.scrollEl.scrollTo(0, 0);
@@ -304,9 +415,9 @@
       freezePage();
     } else if (restoreStyles) {
       restoreScrollStyles();
-      if (state.bucket) {
-        state.bucket.remove();
-        state.bucket = null;
+      if (state.cache) {
+        state.cache.remove();
+        state.cache = null;
       }
     }
     postState();
@@ -328,56 +439,55 @@
     }
   });
 
-// Save MHTML by clicking a hidden <a download> IN THE PAGE (preserves last-used folder)
-chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
-  if (msg?.type === 'ARCHIVER_SAVE_MHTML_VIA_PAGE') {
-    (async () => {
-      try {
-        const { bytes, blobUrl, mime, suggestedName } = msg.payload || {};
+  chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+    if (msg?.type === 'ARCHIVER_SAVE_MHTML_VIA_PAGE') {
+      (async () => {
+        try {
+          const { bytes, blobUrl, mime, suggestedName } = msg.payload || {};
 
-        let blob;
-        if (blobUrl) {
-          const res = await fetch(blobUrl);
-          const fetched = await res.blob();
-          const ab = await fetched.arrayBuffer();
-          blob = new Blob([ab], { type: mime || fetched.type || 'application/x-mimearchive' });
-        } else if (bytes instanceof ArrayBuffer) {
-          blob = new Blob([new Uint8Array(bytes)], { type: mime || 'application/x-mimearchive' });
-        } else if (ArrayBuffer.isView(bytes)) {
-          blob = new Blob([new Uint8Array(bytes.buffer)], { type: mime || 'application/x-mimearchive' });
-        } else if (typeof bytes === 'string' && bytes.startsWith('data:')) {
-          const res = await fetch(bytes);
-          blob = await res.blob();
-          if (mime && blob.type !== mime) {
-            blob = new Blob([await blob.arrayBuffer()], { type: mime });
+          let blob;
+          if (blobUrl) {
+            const res = await fetch(blobUrl);
+            const fetched = await res.blob();
+            const ab = await fetched.arrayBuffer();
+            blob = new Blob([ab], { type: mime || fetched.type || 'application/x-mimearchive' });
+          } else if (bytes instanceof ArrayBuffer) {
+            blob = new Blob([new Uint8Array(bytes)], { type: mime || 'application/x-mimearchive' });
+          } else if (ArrayBuffer.isView(bytes)) {
+            blob = new Blob([new Uint8Array(bytes.buffer)], { type: mime || 'application/x-mimearchive' });
+          } else if (typeof bytes === 'string' && bytes.startsWith('data:')) {
+            const res = await fetch(bytes);
+            blob = await res.blob();
+            if (mime && blob.type !== mime) {
+              blob = new Blob([await blob.arrayBuffer()], { type: mime });
+            }
+          } else {
+            console.warn('[Archiver] unexpected bytes payload:', { type: typeof bytes, ctor: bytes?.constructor?.name });
+            blob = new Blob([], { type: mime || 'application/x-mimearchive' });
           }
-        } else {
-          console.warn('[Archiver] unexpected bytes payload:', { type: typeof bytes, ctor: bytes?.constructor?.name });
-          blob = new Blob([], { type: mime || 'application/x-mimearchive' });
+
+          console.log('[Archiver] save blob size:', blob.size, 'type:', blob.type);
+
+          const url = URL.createObjectURL(blob);
+          const a = document.createElement('a');
+          a.href = url;
+          a.download = suggestedName || 'archive.mhtml';
+          a.style.display = 'none';
+          document.body.appendChild(a);
+          a.click();
+          setTimeout(() => {
+            try { a.remove(); } catch {}
+            try { URL.revokeObjectURL(url); } catch {}
+          }, 300000);
+          sendResponse({ ok: true });
+        } catch (err) {
+          console.error('[Archiver] in-page save failed:', err);
+          sendResponse({ ok: false, error: String(err?.message || err) });
         }
-
-        console.log('[Archiver] save blob size:', blob.size, 'type:', blob.type);
-
-        const url = URL.createObjectURL(blob);              // page-origin blob URL
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = suggestedName || 'archive.mhtml';      // basename only
-        a.style.display = 'none';
-        document.body.appendChild(a);
-        a.click();
-        setTimeout(() => {
-          try { a.remove(); } catch {}
-          try { URL.revokeObjectURL(url); } catch {}
-        }, 300000);
-        sendResponse({ ok: true });
-      } catch (err) {
-        console.error('[Archiver] in-page save failed:', err);
-        sendResponse({ ok: false, error: String(err?.message || err) });
-      }
-    })();
-    return true; // keep the message channel open for sendResponse
-  }
-});
+      })();
+      return true;
+    }
+  });
 
     // Dev helper (console): window.__civitaiArchiverStart()
     window.__civitaiArchiverStart = startRunning;

--- a/manifest.json
+++ b/manifest.json
@@ -16,7 +16,10 @@
     "pageCapture"
   ],
   "host_permissions": [
-    "https://civitai.com/*"
+    "https://civitai.com/*",
+    "https://tensor.art/*",
+    "https://www.tensor.art/*",
+    "https://image.tensorartsassets.com/*"
   ],
   "background": {
     "service_worker": "background.js"
@@ -60,7 +63,9 @@
   "content_scripts": [
     {
       "matches": [
-        "https://civitai.com/*"
+        "https://civitai.com/*",
+        "https://tensor.art/*",
+        "https://www.tensor.art/*"
       ],
       "js": [
         "content/archiver.js"

--- a/manifest.json
+++ b/manifest.json
@@ -19,7 +19,10 @@
     "https://civitai.com/*",
     "https://tensor.art/*",
     "https://www.tensor.art/*",
-    "https://image.tensorartsassets.com/*"
+    "https://image.tensorartsassets.com/*",
+    "https://*.tensorassets.com/*",
+    "https://*.tensorartsassets.com/*",
+    "https://tensor-art.s3.amazonaws.com/*"
   ],
   "background": {
     "service_worker": "background.js"

--- a/styles/bucket.css
+++ b/styles/bucket.css
@@ -1,6 +1,7 @@
 
 /* Simple flex layout for archived items allowing natural image sizes */
-#civitai-archiver-bucket {
+#civitai-archiver-bucket,
+#archiver-cache {
   display: none; /* hidden until freeze */
   box-sizing: border-box;
   padding: 12px;
@@ -8,20 +9,24 @@
   flex-wrap: wrap;
   align-items: flex-start;
 }
-#civitai-archiver-bucket.archiver-freeze {
+#civitai-archiver-bucket.archiver-freeze,
+#archiver-cache.archiver-freeze {
   display: flex !important;
 }
-#civitai-archiver-bucket article {
+#civitai-archiver-bucket article,
+#archiver-cache article {
   border: 1px solid rgba(255,255,255,0.1);
   border-radius: 8px;
   padding: 8px;
   background: #111;
 }
-#civitai-archiver-bucket a {
+#civitai-archiver-bucket a,
+#archiver-cache a {
   text-decoration: none;
   color: inherit;
 }
-#civitai-archiver-bucket img {
+#civitai-archiver-bucket img,
+#archiver-cache img {
   width: auto;
   height: auto;
   display: block;

--- a/tests/archiver.test.js
+++ b/tests/archiver.test.js
@@ -1,6 +1,6 @@
 const path = require('path');
 
-let absUrl, pickBestFromSrcset, isTinyDataURI, resolveImageUrl;
+let absUrl, pickBestFromSrcset, isTinyDataURI, resolveImageUrl, resolveImageUrlCandidates;
 
 beforeAll(() => {
   global.chrome = {
@@ -10,7 +10,7 @@ beforeAll(() => {
     },
     storage: { local: { get: jest.fn() } },
   };
-  ({ absUrl, pickBestFromSrcset, isTinyDataURI, resolveImageUrl } = require('../content/archiver.js'));
+  ({ absUrl, pickBestFromSrcset, isTinyDataURI, resolveImageUrl, resolveImageUrlCandidates } = require('../content/archiver.js'));
 });
 
 describe('archiver utility functions', () => {
@@ -41,5 +41,16 @@ describe('archiver utility functions', () => {
     img.setAttribute('srcset', `${s3} 2048w, ${cdn} 1024w`);
     Object.defineProperty(img, 'currentSrc', { value: cdn, configurable: true });
     expect(resolveImageUrl(img)).toBe(cdn);
+  });
+
+  test('resolveImageUrlCandidates normalizes unique absolute URLs', () => {
+    const img = document.createElement('img');
+    img.setAttribute('src', '/foo.jpg');
+    img.setAttribute('data-src', '//cdn.example.com/foo.jpg');
+    Object.defineProperty(img, 'currentSrc', { value: 'https://tensor.art/foo.jpg', configurable: true });
+    const list = resolveImageUrlCandidates(img);
+    expect(list[0]).toBe('https://tensor.art/foo.jpg');
+    expect(list).toContain('http://localhost/foo.jpg');
+    expect(list).toContain('http://cdn.example.com/foo.jpg');
   });
 });

--- a/tests/archiver.test.js
+++ b/tests/archiver.test.js
@@ -1,6 +1,6 @@
 const path = require('path');
 
-let absUrl, pickBestFromSrcset, isTinyDataURI;
+let absUrl, pickBestFromSrcset, isTinyDataURI, resolveImageUrl;
 
 beforeAll(() => {
   global.chrome = {
@@ -10,7 +10,7 @@ beforeAll(() => {
     },
     storage: { local: { get: jest.fn() } },
   };
-  ({ absUrl, pickBestFromSrcset, isTinyDataURI } = require('../content/archiver.js'));
+  ({ absUrl, pickBestFromSrcset, isTinyDataURI, resolveImageUrl } = require('../content/archiver.js'));
 });
 
 describe('archiver utility functions', () => {
@@ -31,5 +31,15 @@ describe('archiver utility functions', () => {
     expect(isTinyDataURI(tiny)).toBe(true);
     const large = 'data:image/png;base64,' + Buffer.from('a'.repeat(2000)).toString('base64');
     expect(isTinyDataURI(large)).toBe(false);
+  });
+
+  test('resolveImageUrl prefers the displayed currentSrc before srcset candidates', () => {
+    const img = document.createElement('img');
+    const cdn = 'https://image.tensorartsassets.com/foo/bar.jpg';
+    const s3 = 'https://tensor-art.s3.amazonaws.com/foo/bar.jpg';
+    img.setAttribute('src', s3);
+    img.setAttribute('srcset', `${s3} 2048w, ${cdn} 1024w`);
+    Object.defineProperty(img, 'currentSrc', { value: cdn, configurable: true });
+    expect(resolveImageUrl(img)).toBe(cdn);
   });
 });


### PR DESCRIPTION
## Summary
- refactor the content script to use host adapters and add Tensor.Art support with a shared cache-clone pipeline
- update the manifest to include the new host permissions/matches and reuse the cache styling for the new bucket id

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bcf6ca0bc83299bd9c9ecb4f6eb26)